### PR TITLE
📝 (docs): Distill evergreen agent strategy and routing guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ I use it to collect knowledge, configs, prompts, and experiments from my agentic
 - Tooling/config setup and reusable snippets
 - Experiment logs, results, and retrospectives
 
+## Start here
+
+- Strategy overview: `docs/vision/agent-strategy.md`
+- Model routing playbook: `docs/playbooks/model-routing.md`
+- Default interface decision: `docs/decisions/ADR-0001-default-interface-opencode.md`
+
+These docs are intentionally lightweight and biased toward durable ideas over fast-changing vendor details.
+
 ## Why this exists
 
 - Build a reliable personal AI operating system
@@ -20,4 +28,4 @@ I use it to collect knowledge, configs, prompts, and experiments from my agentic
 
 ## Status
 
-Living repository — continuously evolving.
+Living repository. Prefer evergreen principles, repeatable experiments, and dated decisions over static vendor snapshots.

--- a/docs/decisions/ADR-0001-default-interface-opencode.md
+++ b/docs/decisions/ADR-0001-default-interface-opencode.md
@@ -1,0 +1,35 @@
+# ADR-0001: Default Interface is OpenCode
+
+## Status
+
+Accepted
+
+## Context
+
+- I value provider portability and model swapping.
+- The interface/harness has more impact than the model alone.
+- I want a stable daily workflow with optional specialist tools.
+
+## Decision
+
+- Use OpenCode as the default interface.
+- Treat Claude Code and Codex as specialist tools.
+
+## Alternatives considered
+
+- **Claude Code** — strong coding capability but tightly coupled to Anthropic; less portable across providers.
+- **Cursor** — IDE-embedded; good UX but locks workflow into a specific editor and subscription model.
+- **Aider** — open source, terminal-based, provider-agnostic; viable but less polished for agentic multi-step tasks at the time of this decision.
+- **Cline / Roo** — VS Code extension; similar portability to OpenCode but more IDE-dependent.
+
+OpenCode was chosen because it offers provider portability, a stable CLI/config model, and supports subagent routing (explore/general roles) that matches the routing strategy.
+
+## Consequences
+
+- Primary workflow is stable and swappable across providers.
+- Specialist tools are used only for edge cases.
+- Specific model choices can change without reopening this decision.
+
+## Review
+
+- Revisit if a competing harness beats OpenCode on quality and cost.

--- a/docs/playbooks/model-routing.md
+++ b/docs/playbooks/model-routing.md
@@ -1,0 +1,59 @@
+# Model Routing
+
+## Goal
+
+Get consistent results without wasting budget, quota, or attention.
+
+## Use tiers, not fixed model names
+
+- `default`: the model you trust for most real edits
+- `cheap`: search, summarize, classify, and draft options
+- `fallback`: hard debugging, architecture, or recovery when the default model stalls
+
+Keep the tiering stable even when model names change.
+
+## Routing rules
+
+1. Start with the `default` tier for real edits.
+2. Use the `cheap` tier for exploration and triage only.
+3. Escalate to the `fallback` tier only when:
+   - blocked after one focused iteration, or
+   - a bug survives one fix attempt, or
+   - the task needs a broader architectural view than the current model can hold.
+
+## Selection criteria
+
+Choose the current model for each tier based on:
+
+- reliability on your real tasks
+- tool-use quality in your harness
+- speed good enough for the loop you want
+- quota or cost you can sustain every week
+- portability across providers when possible
+
+## Cost and quota control
+
+- Prefer targeted reads over broad scans.
+- Cap exploration depth per step.
+- Require a short summary before escalation.
+- Keep subagents on cheaper tiers by default.
+- Change context before changing models.
+
+## Failure modes
+
+- If usage spikes, reduce exploration depth first.
+- If quality drops, add better context before escalating model strength.
+- If a tier becomes unstable after a provider release, re-evaluate the tier assignment rather than forcing the workflow.
+
+## Maintenance rule
+
+Do not treat this file as a source of truth for live model IDs or pricing.
+Use it to record routing principles only.
+Verify current models, limits, and pricing from live provider sources before changing configs.
+
+## Live references
+
+- OpenCode docs: `https://opencode.ai/docs/`
+- Anthropic pricing: `https://www.anthropic.com/pricing`
+- OpenAI pricing: `https://openai.com/api/pricing/`
+- models.dev model metadata: `https://models.dev`

--- a/docs/vision/agent-strategy.md
+++ b/docs/vision/agent-strategy.md
@@ -1,0 +1,33 @@
+# Agent Strategy
+
+## Core beliefs
+
+- Harness > model for day-to-day output quality.
+- Portability beats lock-in; keep providers swappable.
+- Token quota and token cost are workflow problems, not just model problems.
+
+In API mode, this is mostly a dollar-cost optimization problem.
+In flat-rate subscription mode, this is mostly a quota/rate-limit optimization problem.
+
+## Operating principles
+
+- Use one default interface and one default working setup.
+- Route cheap models to search and summarize only (see `docs/playbooks/model-routing.md`).
+- Escalate to strong models only when stuck.
+- Prefer small, explicit context over broad scans.
+
+## Governance
+
+- Cap exploration depth per task.
+- Require summaries between loops.
+- Avoid auto-scanning entire repos by default.
+
+## Review cadence
+
+- Weekly: record what worked and what burned quota/tokens.
+- Monthly: refresh routing rules and benchmark results.
+
+## Durability rule
+
+- Keep principles here; keep volatile vendor facts out.
+- If a document depends on current model names, prices, or quotas, treat it as a live reference, not durable knowledge.


### PR DESCRIPTION
Keep only the durable parts of the AI-agent knowledge base so the repo stays useful as vendor details change quickly. Replace version-specific routing notes with stable principles, record the OpenCode decision more clearly, and drop unused benchmark/template scaffolding.
