### PR TITLE
🐛 fix(lwot): Check branch safety before edits

### DIFF
--- a/prompts/lwot.md
+++ b/prompts/lwot.md
@@ -23,11 +23,10 @@ Use the optional argument after `/lwot` as the thing we should work from. It may
    - If no argument is provided, infer what "that" refers to from the conversation.
    - If it is still unclear, ask a concise clarifying question before proceeding.
 
-2. **Check branch safety before repository changes**
-   - Before making edits, check the current git branch.
-   - Treat `main`, the repository default branch, and any explicitly protected branch as branches you should not work on directly.
-   - If you are on one of those branches, create and switch to a new branch that follows the repository naming convention before editing files.
-   - If you are already on a non-protected feature branch, continue work there.
+2. **Check branch safety**
+   - Check the current git branch and note whether it is a protected/default branch (`main` or equivalent).
+   - This is a read-only check only — do not create or switch branches yet.
+   - If already on a non-protected feature branch, note that and continue.
 
 3. **Gather the minimum context needed**
    - **Free text**: restate the goal in your own words and inspect the repository as needed.
@@ -50,6 +49,7 @@ Use the optional argument after `/lwot` as the thing we should work from. It may
 
 6. **Do the work**
    - Only start implementation once you have either user confirmation or a truly straightforward request that is clearly asking for execution now.
+   - If Step 2 flagged a protected branch, create and switch to a properly named branch now, before touching any files. Use the repository naming convention (`<firstname>/<type>/<topic-more_info>`, where type is one of `feature`, `bugfix`, or `release`) with a topic slug derived from the work context gathered in Steps 3–4.
    - Keep changes minimal and directly tied to the request.
    - Match existing style and avoid unrelated refactors.
    - Use GitHub context and linked URLs as supporting material, not as permission to expand scope.

--- a/prompts/lwot.md
+++ b/prompts/lwot.md
@@ -23,32 +23,38 @@ Use the optional argument after `/lwot` as the thing we should work from. It may
    - If no argument is provided, infer what "that" refers to from the conversation.
    - If it is still unclear, ask a concise clarifying question before proceeding.
 
-2. **Gather the minimum context needed**
+2. **Check branch safety before repository changes**
+   - Before making edits, check the current git branch.
+   - Treat `main`, the repository default branch, and any explicitly protected branch as branches you should not work on directly.
+   - If you are on one of those branches, create and switch to a new branch that follows the repository naming convention before editing files.
+   - If you are already on a non-protected feature branch, continue work there.
+
+3. **Gather the minimum context needed**
    - **Free text**: restate the goal in your own words and inspect the repository as needed.
    - **GitHub issue or PR**: use the `gh` CLI (or the URL directly) to read the title, body, status, and the most relevant comments or review notes.
    - **Todo ID**: read the todo with the `todo` tool (`action: get, id: <id>`) to retrieve its title, body, and status.
    - **Other URL**: fetch or read the page or resource and extract only the parts needed to do the work.
    - If a URL cannot be accessed because of auth, networking, or unsupported content, say so plainly and ask the user to paste the relevant context.
 
-3. **Frame the work before changing code**
+4. **Frame the work before changing code**
    - State your assumptions.
    - Define the smallest useful outcome.
    - Give a short plan before starting work, especially for anything non-trivial.
    - Unless the task is truly straightforward and the user's intent to implement is explicit, ask for confirmation before making changes.
 
-4. **Choose the right path**
+5. **Choose the right path**
    - For very small, clear, implementation-ready work, proceed directly.
    - For anything that may still be under discussion, present the plan and ask whether to proceed.
    - For meaningful multi-step work, propose using OpenSpec (`/pac-propose` then `/pac-apply`) before implementation.
    - If the input is exploratory rather than actionable, suggest `/pac-explore`.
 
-5. **Do the work**
+6. **Do the work**
    - Only start implementation once you have either user confirmation or a truly straightforward request that is clearly asking for execution now.
    - Keep changes minimal and directly tied to the request.
    - Match existing style and avoid unrelated refactors.
    - Use GitHub context and linked URLs as supporting material, not as permission to expand scope.
 
-6. **Verify and report**
+7. **Verify and report**
    - Run the smallest relevant checks.
    - Summarize what you changed, what you verified, and any open questions.
 


### PR DESCRIPTION
Ensure /lwot checks whether it is on main or another protected/default branch before repository work begins, so branch setup happens intentionally before file edits start.

closes #69
