### PR TITLE
✨ feat(extensions): Add /ask mode for  discussion-only mid-implementation

### DIFF
--- a/extensions/ask/ask.test.mjs
+++ b/extensions/ask/ask.test.mjs
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { filterAskModeMessages, getAskModeStateFromBranch } from "./helpers.ts";
+
+test("removes ask-mode-context custom messages", () => {
+	const messages = [
+		{ customType: "ask-mode-context", content: "[ASK MODE ACTIVE]\n...", display: false },
+		{ role: "user", content: "hello" },
+	];
+	const result = filterAskModeMessages(messages);
+	assert.equal(result.length, 1);
+	assert.deepEqual(result[0], { role: "user", content: "hello" });
+});
+
+test("keeps user messages with [ASK MODE ACTIVE] string content", () => {
+	const messages = [
+		{ role: "user", content: "[ASK MODE ACTIVE]\nDo not make changes." },
+		{ role: "user", content: "normal message" },
+	];
+	const result = filterAskModeMessages(messages);
+	assert.equal(result.length, 2);
+});
+
+test("keeps user messages with [ASK MODE ACTIVE] in array content", () => {
+	const messages = [
+		{ role: "user", content: [{ type: "text", text: "[ASK MODE ACTIVE]\nDo not make changes." }] },
+		{ role: "user", content: [{ type: "text", text: "normal" }] },
+	];
+	const result = filterAskModeMessages(messages);
+	assert.equal(result.length, 2);
+});
+
+test("keeps assistant messages regardless of content", () => {
+	const messages = [
+		{ role: "assistant", content: [{ type: "text", text: "I'm in ask mode and won't make changes." }] },
+		{ role: "user", content: "normal" },
+	];
+	const result = filterAskModeMessages(messages);
+	assert.equal(result.length, 2);
+});
+
+test("keeps ask-mode-end messages", () => {
+	const messages = [
+		{ customType: "ask-mode-end", content: "[ASK MODE ENDED]\n...", display: false },
+		{ role: "user", content: "can you run bash?" },
+	];
+	const result = filterAskModeMessages(messages);
+	assert.equal(result.length, 2);
+});
+
+test("keeps normal messages untouched", () => {
+	const messages = [
+		{ role: "user", content: "just a question" },
+		{ role: "assistant", content: [{ type: "text", text: "here is the answer" }] },
+	];
+	const result = filterAskModeMessages(messages);
+	assert.equal(result.length, 2);
+});
+
+test("returns empty array for empty input", () => {
+	assert.deepEqual(filterAskModeMessages([]), []);
+});
+
+test("restores ask mode state from custom state entries", () => {
+	const state = getAskModeStateFromBranch([
+		{ type: "custom", customType: "ask-mode-state", data: { enabled: true, savedTools: ["read", "bash"] } },
+		{ type: "custom", customType: "ask-mode-state", data: { enabled: false, savedTools: [] } },
+	]);
+
+	assert.deepEqual(state, { enabled: false, savedTools: [] });
+});
+
+test("derives legacy ask mode state from custom messages", () => {
+	const enabled = getAskModeStateFromBranch([
+		{ type: "custom_message", customType: "ask-mode-context" },
+	]);
+	assert.deepEqual(enabled, { enabled: true, savedTools: undefined });
+
+	const disabled = getAskModeStateFromBranch([
+		{ type: "custom_message", customType: "ask-mode-context" },
+		{ type: "custom_message", customType: "ask-mode-end" },
+	]);
+	assert.deepEqual(disabled, { enabled: false, savedTools: undefined });
+});

--- a/extensions/ask/helpers.ts
+++ b/extensions/ask/helpers.ts
@@ -1,0 +1,95 @@
+/**
+ * Pure helper functions for ask mode.
+ * Extracted for testability.
+ */
+
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
+export const ASK_MODE_TOOLS = ["read"];
+export const ASK_MODE_CONTEXT_TYPE = "ask-mode-context";
+export const ASK_MODE_END_TYPE = "ask-mode-end";
+export const ASK_MODE_STATE_TYPE = "ask-mode-state";
+
+export const ASK_PROMPT = `[ASK MODE ACTIVE]
+The user wants to discuss or ask a question. Do not take any action.
+
+Rules — follow all of them strictly:
+- Do NOT edit or write any files
+- Do NOT run any shell commands
+- Do NOT make any code changes
+- Just answer, discuss, and think things through conversationally
+
+Stay in this mode until the user exits with /ask.`;
+
+export const ASK_MODE_END = `[ASK MODE ENDED]
+Ask mode is off. You have full tool access again (read, bash, edit, write). Proceed normally.`;
+
+type AugmentedMessage = AgentMessage & { customType?: string };
+
+type AskModeStateEntry = {
+	type: string;
+	customType?: string;
+	data?: unknown;
+};
+
+export interface AskModeState {
+	enabled: boolean;
+	savedTools?: string[];
+}
+
+function parseAskModeState(data: unknown): AskModeState {
+	if (!data || typeof data !== "object") {
+		throw new Error("Invalid ask-mode state: expected object data");
+	}
+
+	const { enabled, savedTools } = data as { enabled?: unknown; savedTools?: unknown };
+	if (typeof enabled !== "boolean") {
+		throw new Error("Invalid ask-mode state: expected boolean enabled flag");
+	}
+	if (!Array.isArray(savedTools) || savedTools.some((tool) => typeof tool !== "string")) {
+		throw new Error("Invalid ask-mode state: expected savedTools string[]");
+	}
+
+	return { enabled, savedTools };
+}
+
+export function getAskModeStateFromBranch(entries: AskModeStateEntry[]): AskModeState | undefined {
+	let state: AskModeState | undefined;
+
+	for (const entry of entries) {
+		if (entry.type === "custom" && entry.customType === ASK_MODE_STATE_TYPE) {
+			state = parseAskModeState(entry.data);
+			continue;
+		}
+
+		if (entry.type !== "custom_message") {
+			continue;
+		}
+
+		if (entry.customType === ASK_MODE_CONTEXT_TYPE) {
+			state = { enabled: true, savedTools: state?.savedTools };
+			continue;
+		}
+
+		if (entry.customType === ASK_MODE_END_TYPE) {
+			state = { enabled: false, savedTools: state?.savedTools };
+		}
+	}
+
+	return state;
+}
+
+/**
+ * Removes ask-mode-context injections from the message list.
+ * Called when ask mode is off to prevent old "I won't make changes" markers
+ * from bleeding into normal turns.
+ *
+ * The [ASK MODE ENDED] marker (ask-mode-end) is intentionally kept —
+ * it helps the model understand the mode transition.
+ */
+export function filterAskModeMessages(messages: AgentMessage[]): AgentMessage[] {
+	return messages.filter((m) => {
+		const msg = m as AugmentedMessage;
+		return msg.customType !== ASK_MODE_CONTEXT_TYPE;
+	});
+}

--- a/extensions/ask/index.ts
+++ b/extensions/ask/index.ts
@@ -83,8 +83,20 @@ export default function askExtension(pi: ExtensionAPI): void {
 	}
 
 	pi.registerCommand("ask", {
-		description: "Toggle ask mode: discuss and ask questions without triggering any changes",
-		handler: async (_args, ctx) => toggleAskMode(ctx),
+		description: "Toggle ask mode or ask a question in discussion mode",
+		handler: async (args, ctx) => {
+			const question = args?.trim();
+			if (!question) {
+				toggleAskMode(ctx);
+				return;
+			}
+
+			if (!askModeEnabled) {
+				toggleAskMode(ctx);
+			}
+
+			pi.sendUserMessage(question);
+		},
 	});
 
 	// When ask mode is off, remove the extension's hidden ask-mode injections

--- a/extensions/ask/index.ts
+++ b/extensions/ask/index.ts
@@ -1,0 +1,106 @@
+/**
+ * Ask Mode Extension
+ *
+ * A lightweight discussion-only mode for asking questions and thinking
+ * things through mid-implementation without triggering any code changes.
+ *
+ * Usage:
+ * - /ask to toggle ask mode on/off
+ */
+
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import {
+	ASK_PROMPT,
+	ASK_MODE_CONTEXT_TYPE,
+	ASK_MODE_END,
+	ASK_MODE_END_TYPE,
+	ASK_MODE_STATE_TYPE,
+	ASK_MODE_TOOLS,
+	filterAskModeMessages,
+	getAskModeStateFromBranch,
+} from "./helpers.js";
+
+export default function askExtension(pi: ExtensionAPI): void {
+	let askModeEnabled = false;
+	let savedTools: string[] = [];
+
+	function updateStatus(ctx: ExtensionContext): void {
+		ctx.ui.setStatus("ask-mode", askModeEnabled ? ctx.ui.theme.fg("warning", "💬 ask") : undefined);
+	}
+
+	function restoreFromBranch(ctx: ExtensionContext): void {
+		const branchState = getAskModeStateFromBranch(ctx.sessionManager.getBranch());
+		const wasEnabled = askModeEnabled;
+
+		if (!branchState?.enabled) {
+			askModeEnabled = false;
+			if (branchState?.savedTools !== undefined) {
+				savedTools = [...branchState.savedTools];
+			}
+			if (wasEnabled) {
+				pi.setActiveTools(savedTools);
+			}
+			updateStatus(ctx);
+			return;
+		}
+
+		if (branchState.savedTools !== undefined) {
+			savedTools = [...branchState.savedTools];
+		} else if (!wasEnabled) {
+			savedTools = pi.getActiveTools();
+		}
+
+		askModeEnabled = true;
+		pi.setActiveTools(ASK_MODE_TOOLS);
+		updateStatus(ctx);
+	}
+
+	function toggleAskMode(ctx: ExtensionContext): void {
+		askModeEnabled = !askModeEnabled;
+
+		if (askModeEnabled) {
+			savedTools = [...pi.getActiveTools()];
+			pi.appendEntry(ASK_MODE_STATE_TYPE, { enabled: true, savedTools });
+			pi.setActiveTools(ASK_MODE_TOOLS);
+			updateStatus(ctx);
+			ctx.ui.notify("Ask mode on — no changes will be made. Use /ask to exit.");
+			pi.sendMessage(
+				{ customType: ASK_MODE_CONTEXT_TYPE, content: ASK_PROMPT, display: false },
+				{ triggerTurn: false },
+			);
+		} else {
+			pi.appendEntry(ASK_MODE_STATE_TYPE, { enabled: false, savedTools });
+			pi.setActiveTools(savedTools);
+			updateStatus(ctx);
+			ctx.ui.notify("Ask mode off — full access restored.");
+			// Explicit end marker so the model sees the mode change in context
+			// and is not confused by its own earlier "I won't make changes" responses.
+			pi.sendMessage(
+				{ customType: ASK_MODE_END_TYPE, content: ASK_MODE_END, display: false },
+				{ triggerTurn: false },
+			);
+		}
+	}
+
+	pi.registerCommand("ask", {
+		description: "Toggle ask mode: discuss and ask questions without triggering any changes",
+		handler: async (_args, ctx) => toggleAskMode(ctx),
+	});
+
+	// When ask mode is off, remove the extension's hidden ask-mode injections
+	// from context so stale restriction markers do not bleed into normal turns.
+	// The [ASK MODE ENDED] marker is intentionally kept — it helps the model
+	// understand the mode transition.
+	pi.on("context", async (event) => {
+		if (askModeEnabled) return;
+		return { messages: filterAskModeMessages(event.messages) };
+	});
+
+	pi.on("session_start", async (_event, ctx) => {
+		restoreFromBranch(ctx);
+	});
+
+	pi.on("session_tree", async (_event, ctx) => {
+		restoreFromBranch(ctx);
+	});
+}


### PR DESCRIPTION
 Adds a lightweight toggle that locks the agent to read-only tools and
 injects a no-action instruction, so the user can ask questions and think
 things through without risk of triggering unintended edits.

 - /ask on: saves active tools, restricts to [read], injects ASK_PROMPT
 - /ask off: restores saved tools, clears status badge and context injection
 - context filter removes the injected message from future turns once off
 - stays in the main thread (no isolation, no overlap with /btw)

 closes #61
