### PR TITLE
📝 docs(readme): Document npm ci in onboarding flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ It is set up to be used with **[pi](https://github.com/badlogic/pi-mono/tree/mai
 ## Start here
 
 For day-to-day work in this repo, the README is the source of truth.
+On a fresh clone, install Node dependencies with `npm ci` before launching Pi so repo extensions can load cleanly.
+
+```bash
+npm ci
+```
+
 Use Pi locally with:
 
 ```bash
@@ -77,24 +83,27 @@ Please set up the `mypac` repository on this machine.
 
 Important:
 - Ask me for any missing values before acting, especially the clone location and whether you should install any missing prerequisites.
+- Install Node dependencies with `npm ci` in the cloned repo before relying on any repo-provided Pi extensions.
 - Do not replace existing entries in `~/.pi/agent/settings.json`; only add the `mypac` repo path to the `packages` array if it is missing.
 - If you hit an auth, permission, or missing-tool problem, stop and tell me exactly what you need from me.
 
 Tasks:
 1. Confirm where I want to clone `https://github.com/ladislas/mypac.git`, then clone it there.
-2. Read the cloned `README.md` and follow the documented setup for this repo.
-3. Ensure `~/.pi/agent/settings.json` exists and that its `packages` array includes the cloned repository path.
-4. From the repository root, run:
+2. From the cloned repository root, run `npm ci` to install Node dependencies.
+3. Read the cloned `README.md` and follow the documented setup for this repo.
+4. Ensure `~/.pi/agent/settings.json` exists and that its `packages` array includes the cloned repository path.
+5. From the repository root, run:
    - `mise trust`
    - `mise install`
    - `mise run hooks`
-5. Verify the setup by:
+6. Verify the setup by:
+   - confirming `npm ci` completed successfully
    - confirming the package path was added to `~/.pi/agent/settings.json`
    - confirming the repo contains `prompts/`, `extensions/`, and `skills/`
    - telling me to launch Pi in the repo with `mise run pi`
    - once Pi is running from the repo, asking me to try `/hello-world`
    - telling me whether I need to restart Pi so it reloads the updated package settings
-6. Summarize what you changed, what you verified, and any follow-up steps for me.
+7. Summarize what you changed, what you verified, and any follow-up steps for me.
 
 If `mise` is not installed and I want you to install it, use Homebrew: `brew install mise`.
 ```


### PR DESCRIPTION
Clarify that fresh clones should install Node dependencies before relying on repo-provided Pi extensions.

closes #81
