### PR TITLE
📝 docs(prompts): Add closes keyword reminder to lwot Step 6

### DIFF
--- a/prompts/pac-lwot.md
+++ b/prompts/pac-lwot.md
@@ -52,6 +52,7 @@ Use the optional argument after `/pac-lwot` as the thing we should work from. It
    - Only start implementation once you have either user confirmation or a truly straightforward request that is clearly asking for execution now.
    - If Step 2 flagged a protected branch, create and switch to a properly named branch now, before touching any files. Use the repository naming convention (`<firstname>/<type>/<topic-more_info>`, where type is one of `feature`, `bugfix`, or `release`) with a topic slug derived from the work context gathered in Steps 3–4.
    - For meaningful completed slices of work, create atomic commits during implementation rather than waiting until the very end.
+   - If the work originated from a GitHub issue (passed as the argument), include `closes #<issue-number>` in the commit body of the commit that resolves the issue. Do not guess issue numbers.
    - Keep changes minimal and directly tied to the request.
    - Match existing style and avoid unrelated refactors.
    - Use GitHub context and linked URLs as supporting material, not as permission to expand scope.


### PR DESCRIPTION
When the work originates from a GitHub issue passed as the lwot argument,
the prompt now explicitly instructs including `closes #<issue-number>` in
the fix commit body so the issue auto-closes on merge.

closes #99
