### PR TITLE
ladislas/bugfix/btw pane border visibility right spacing

### DIFF
--- a/extensions/btw/index.ts
+++ b/extensions/btw/index.ts
@@ -325,7 +325,7 @@ class BtwOverlay extends Container implements Focusable {
 		this.onDismissCallback = onDismiss;
 
 		const editorTheme: EditorTheme = {
-			borderColor: (s) => theme.fg("borderMuted", s),
+			borderColor: (s) => theme.fg("borderAccent", s),
 			selectList: {
 				selectedPrefix: (t) => theme.fg("accent", t),
 				selectedText: (t) => theme.fg("accent", t),

--- a/extensions/btw/index.ts
+++ b/extensions/btw/index.ts
@@ -395,9 +395,9 @@ class BtwOverlay extends Container implements Focusable {
 		// Render editor first so we know how many lines it occupies
 		const editorLines = this.editor.render(innerWidth);
 
-		// Static chrome: top border + title + subtitle + 2 separators + status + hints + bottom border
-		const staticChrome = 8;
-		const transcriptHeight = Math.max(4, dialogHeight - staticChrome - editorLines.length);
+		// Static chrome: top border + title + subtitle + 2 separators + status + 2 hint lines + bottom border
+		const staticChrome = 9;
+		const transcriptHeight = Math.max(0, dialogHeight - staticChrome - editorLines.length);
 
 		// Markdown renders to innerWidth already — no manual wrapping needed
 		const transcript = this.getTranscript(innerWidth, this.theme);
@@ -410,14 +410,16 @@ class BtwOverlay extends Container implements Focusable {
 		const linesBelow = this.scrollOffset;
 		const linesAbove = Math.max(0, totalLines - transcriptHeight - linesBelow);
 
-		// Reserve one slot each for scroll indicators when there is hidden content
-		const topSlot = linesAbove > 0 ? 1 : 0;
-		const bottomSlot = linesBelow > 0 ? 1 : 0;
-		const contentSlots = transcriptHeight - topSlot - bottomSlot;
+		// Reserve indicator slots only when the transcript area has room for them.
+		const showTopIndicator = linesAbove > 0 && transcriptHeight > 0;
+		const showBottomIndicator = linesBelow > 0 && transcriptHeight > (showTopIndicator ? 1 : 0);
+		const topSlot = showTopIndicator ? 1 : 0;
+		const bottomSlot = showBottomIndicator ? 1 : 0;
+		const contentSlots = Math.max(0, transcriptHeight - topSlot - bottomSlot);
 
 		const endIdx = totalLines - linesBelow;
-		const startIdx = endIdx - contentSlots;
-		const visibleTranscript = transcript.slice(Math.max(0, startIdx), Math.max(0, endIdx));
+		const startIdx = Math.max(0, endIdx - contentSlots);
+		const visibleTranscript = transcript.slice(startIdx, Math.max(0, endIdx));
 		const transcriptPadding = Math.max(0, contentSlots - visibleTranscript.length);
 
 		const status = this.getStatus();
@@ -430,7 +432,7 @@ class BtwOverlay extends Container implements Focusable {
 			this.theme.fg("border", `├${"─".repeat(innerWidth)}┤`),
 		];
 
-		if (linesAbove > 0) {
+		if (showTopIndicator) {
 			lines.push(this.frameLine(this.theme.fg("dim", `↑ ${linesAbove} more line${linesAbove === 1 ? "" : "s"} above`), innerWidth));
 		}
 		for (const line of visibleTranscript) {
@@ -439,7 +441,7 @@ class BtwOverlay extends Container implements Focusable {
 		for (let i = 0; i < transcriptPadding; i++) {
 			lines.push(this.frameLine("", innerWidth));
 		}
-		if (linesBelow > 0) {
+		if (showBottomIndicator) {
 			lines.push(this.frameLine(this.theme.fg("dim", `↓ ${linesBelow} more line${linesBelow === 1 ? "" : "s"} below`), innerWidth));
 		}
 
@@ -454,7 +456,7 @@ class BtwOverlay extends Container implements Focusable {
 		);
 		lines.push(this.borderLine(innerWidth, "bottom"));
 
-		return ["", ...lines.map((l) => `   ${l}`), ""];
+		return lines.map((l) => `   ${l}`);
 	}
 }
 

--- a/extensions/btw/index.ts
+++ b/extensions/btw/index.ts
@@ -449,10 +449,8 @@ class BtwOverlay extends Container implements Focusable {
 			lines.push(this.frameLine(line, innerWidth));
 		}
 		lines.push(
-			this.frameLine(
-				this.theme.fg("dim", "PgUp/PgDn scroll · Enter submit · Shift+Enter newline · /import import/refresh · Esc close"),
-				innerWidth,
-			),
+			this.frameLine(this.theme.fg("dim", "PgUp/PgDn scroll · Enter submit · Shift+Enter newline"), innerWidth),
+			this.frameLine(this.theme.fg("dim", "/import import/refresh · Esc close"), innerWidth),
 		);
 		lines.push(this.borderLine(innerWidth, "bottom"));
 

--- a/extensions/btw/index.ts
+++ b/extensions/btw/index.ts
@@ -377,17 +377,17 @@ class BtwOverlay extends Container implements Focusable {
 	private frameLine(content: string, innerWidth: number): string {
 		const truncated = truncateToWidth(content, innerWidth, "");
 		const padding = Math.max(0, innerWidth - visibleWidth(truncated));
-		return `${this.theme.fg("borderMuted", "│")}${truncated}${" ".repeat(padding)}${this.theme.fg("borderMuted", "│")}`;
+		return `${this.theme.fg("border", "│")}${truncated}${" ".repeat(padding)}${this.theme.fg("border", "│")}`;
 	}
 
 	private borderLine(innerWidth: number, edge: "top" | "bottom"): string {
 		const left = edge === "top" ? "┌" : "└";
 		const right = edge === "top" ? "┐" : "┘";
-		return this.theme.fg("borderMuted", `${left}${"─".repeat(innerWidth)}${right}`);
+		return this.theme.fg("border", `${left}${"─".repeat(innerWidth)}${right}`);
 	}
 
 		override render(width: number): string[] {
-		const dialogWidth = Math.max(56, Math.min(width, Math.floor(width * 0.9)));
+		const dialogWidth = width - 6;
 		const innerWidth = Math.max(40, dialogWidth - 2);
 		const terminalRows = process.stdout.rows ?? 30;
 		const dialogHeight = Math.max(16, Math.min(30, Math.floor(terminalRows * 0.75)));
@@ -427,7 +427,7 @@ class BtwOverlay extends Container implements Focusable {
 			this.borderLine(innerWidth, "top"),
 			this.frameLine(this.theme.fg("accent", this.theme.bold(" BTW side chat ")), innerWidth),
 			this.frameLine(this.theme.fg("dim", `Isolated side conversation. ${importHint}`), innerWidth),
-			this.theme.fg("borderMuted", `├${"─".repeat(innerWidth)}┤`),
+			this.theme.fg("border", `├${"─".repeat(innerWidth)}┤`),
 		];
 
 		if (linesAbove > 0) {
@@ -443,7 +443,7 @@ class BtwOverlay extends Container implements Focusable {
 			lines.push(this.frameLine(this.theme.fg("dim", `↓ ${linesBelow} more line${linesBelow === 1 ? "" : "s"} below`), innerWidth));
 		}
 
-		lines.push(this.theme.fg("borderMuted", `├${"─".repeat(innerWidth)}┤`));
+		lines.push(this.theme.fg("border", `├${"─".repeat(innerWidth)}┤`));
 		lines.push(this.frameLine(this.theme.fg("warning", status), innerWidth));
 		for (const line of editorLines) {
 			lines.push(this.frameLine(line, innerWidth));
@@ -456,7 +456,7 @@ class BtwOverlay extends Container implements Focusable {
 		);
 		lines.push(this.borderLine(innerWidth, "bottom"));
 
-		return lines;
+		return ["", ...lines.map((l) => `   ${l}`), ""];
 	}
 }
 
@@ -1248,7 +1248,7 @@ export default function (pi: ExtensionAPI) {
 				{
 					overlay: true,
 					overlayOptions: {
-						width: "80%",
+						width: "88%",
 						minWidth: 72,
 						maxHeight: "78%",
 						anchor: "top-center",


### PR DESCRIPTION
- **🐛 fix(btw): Fix pane border visibility and right-side layout spacing**
- **💄 fix(btw): Split hint bar into two lines to avoid truncation**
- **💄 fix(btw): Use normal border color for editor input box border**
- **🐛 fix(btw): Keep overlay height within dialog budget**
