### PR TITLE
✨ feat(ghi): Add create-only /ghi command

### DIFF
--- a/extensions/ghi/ghi.test.mjs
+++ b/extensions/ghi/ghi.test.mjs
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildIssueCreatePrompt, loadIssueCreateSkill, normalizeIssueNote } from "./helpers.ts";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+test("normalizeIssueNote trims surrounding whitespace", () => {
+	assert.equal(normalizeIssueNote("  fix README install steps  \n"), "fix README install steps");
+});
+
+test("buildIssueCreatePrompt keeps the issue note at the end", () => {
+	const prompt = buildIssueCreatePrompt("Skill instructions", "Need a better /ghi MVP");
+	assert.ok(prompt.startsWith("Skill instructions\n\n---\n\nCreate a GitHub issue"));
+	assert.ok(prompt.endsWith("Issue note:\nNeed a better /ghi MVP"));
+});
+
+test("loadIssueCreateSkill returns trimmed file content", async () => {
+	const dir = await mkdtemp(path.join(tmpdir(), "ghi-skill-"));
+	const skillPath = path.join(dir, "SKILL.md");
+	await writeFile(skillPath, "\n  Example skill content\n\n", "utf8");
+
+	assert.equal(await loadIssueCreateSkill(skillPath), "Example skill content");
+});
+
+test("loadIssueCreateSkill returns null when the file is missing", async () => {
+	const dir = await mkdtemp(path.join(tmpdir(), "ghi-skill-missing-"));
+	const skillPath = path.join(dir, "missing.md");
+
+	assert.equal(await loadIssueCreateSkill(skillPath), null);
+});

--- a/extensions/ghi/helpers.ts
+++ b/extensions/ghi/helpers.ts
@@ -1,0 +1,43 @@
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+
+export const ISSUE_CREATE_SKILL_PATH = path.resolve(
+	currentDir,
+	"..",
+	"..",
+	"skills",
+	"pac-github-issue-create",
+	"SKILL.md",
+);
+
+export async function loadIssueCreateSkill(skillPath: string = ISSUE_CREATE_SKILL_PATH): Promise<string | null> {
+	try {
+		const content = await fs.readFile(skillPath, "utf8");
+		const trimmed = content.trim();
+		return trimmed || null;
+	} catch {
+		return null;
+	}
+}
+
+export function normalizeIssueNote(input: string): string {
+	return input.trim();
+}
+
+export function buildIssueCreatePrompt(skillContent: string, note: string): string {
+	return [
+		skillContent.trim(),
+		"",
+		"---",
+		"",
+		"Create a GitHub issue for the current repository based on the note below.",
+		"Stay within this create-only /ghi workflow.",
+		"If the note is too ambiguous to create a useful issue, ask at most one brief follow-up question before creating it.",
+		"",
+		"Issue note:",
+		normalizeIssueNote(note),
+	].join("\n");
+}

--- a/extensions/ghi/index.ts
+++ b/extensions/ghi/index.ts
@@ -1,0 +1,43 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { buildIssueCreatePrompt, loadIssueCreateSkill, normalizeIssueNote } from "./helpers.ts";
+
+export default function ghiExtension(pi: ExtensionAPI): void {
+	pi.registerCommand("ghi", {
+		description: "Create a GitHub issue in the current repository",
+		handler: async (args, ctx) => {
+			if (!ctx.isIdle()) {
+				ctx.ui.notify("/ghi can only run while the agent is idle", "warning");
+				return;
+			}
+
+			const repoCheck = await pi.exec("git", ["rev-parse", "--is-inside-work-tree"]);
+			if (repoCheck.code !== 0 || repoCheck.stdout.trim() !== "true") {
+				ctx.ui.notify("/ghi must be run inside a git repository", "error");
+				return;
+			}
+
+			let note = normalizeIssueNote(args ?? "");
+			if (!note) {
+				if (!ctx.hasUI) {
+					ctx.ui.notify("Provide an issue note, for example: /ghi fix README install steps", "error");
+					return;
+				}
+
+				const input = await ctx.ui.input("Create GitHub issue", "Short issue note or title");
+				note = normalizeIssueNote(input ?? "");
+				if (!note) {
+					ctx.ui.notify("Issue creation cancelled", "info");
+					return;
+				}
+			}
+
+			const skillContent = await loadIssueCreateSkill();
+			if (!skillContent) {
+				ctx.ui.notify("Could not load skills/pac-github-issue-create/SKILL.md", "error");
+				return;
+			}
+
+			pi.sendUserMessage(buildIssueCreatePrompt(skillContent, note));
+		},
+	});
+}

--- a/skills/pac-github-issue-create/SKILL.md
+++ b/skills/pac-github-issue-create/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: pac-github-issue-create
+description: "Create a GitHub issue in the current repository with gh. Use when the user wants to capture work as an issue from Pi or through the /ghi command."
+---
+
+# GitHub issue creation skill
+
+Use this skill when the user wants to create a GitHub issue in the current repository.
+
+## Goal
+
+Turn the provided note into a useful GitHub issue with:
+
+- a concise title
+- a structured body
+- a created issue URL returned to the user
+
+## Workflow
+
+1. Confirm you are in a git repository:
+
+   ```bash
+   git rev-parse --is-inside-work-tree
+   ```
+
+   If this fails, stop and explain that issue creation must run inside a git repository.
+
+2. Confirm `gh` is available:
+
+   ```bash
+   gh --version
+   ```
+
+   If this fails, stop and explain that the GitHub CLI is required.
+
+3. Resolve the current repository with GitHub CLI:
+
+   ```bash
+   gh repo view --json nameWithOwner --jq .nameWithOwner
+   ```
+
+   If this fails, stop and explain that `gh` must be authenticated and have access to the repository.
+
+4. Use the provided note to draft the issue.
+
+   - If the note already reads like a good issue title, you may reuse it.
+   - Otherwise, derive a short imperative or descriptive title.
+   - Ask at most one brief follow-up question only if the note is too ambiguous to create a useful issue.
+
+5. Create a structured issue body with these sections:
+
+   ```md
+   ## Summary
+
+   <short summary>
+
+   ## Motivation
+
+   <why this matters>
+
+   ## Acceptance Criteria
+
+   - [ ] <first concrete outcome>
+   - [ ] <second concrete outcome>
+   ```
+
+   Keep the body proportional to the note. For a tiny note, stay concise.
+
+6. Create the issue with `gh issue create` against the current repository.
+
+   Prefer passing the repo explicitly:
+
+   ```bash
+   gh issue create --repo <owner/repo> --title "<title>" --body-file <temp-file>
+   ```
+
+   Use a temp file for the body when that is simpler than shell escaping.
+
+7. Return the created issue URL to the user.
+
+## Constraints
+
+- This skill is only for creating an issue, not listing, opening, closing, or reviewing issues.
+- Do not broaden scope beyond the provided note.
+- Surface `gh` errors clearly instead of paraphrasing them away.
+- If creation succeeds, include the final issue URL in the response.


### PR DESCRIPTION
Start the /ghi workflow with a small extension-backed issue creator.
Keep GitHub issue creation instructions in a focused skill and defer broader issue management for later.
