### PR TITLE
📝 docs(changelog): Add changelog and release playbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this repository will be documented in this file.
+
+This changelog uses an `Unreleased` section for in-flight work and grouped headings inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the release note format used in [pi-mono](https://github.com/badlogic/pi-mono/blob/084aa2b54d1131c63774133a6a4197be35ba94c3/packages/coding-agent/CHANGELOG.md).
+
+Versioned sections should match the Git tags and GitHub releases published for this repository.
+
+## [Unreleased]
+
+### Added
+
+- Added this changelog to track notable repository changes and future GitHub releases. ([#139](https://github.com/ladislas/mypac/issues/139))
+
+### Changed
+
+- Added a repo-local skill for updating `CHANGELOG.md` during normal agent-driven work and preparing release sections on request. ([#139](https://github.com/ladislas/mypac/issues/139))

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ For readability, the skill table below drops the `pac-` prefix in the display la
 
 | Skill | What it is for |
 | --- | --- |
+| [`changelog`](skills/pac-changelog/SKILL.md) | Update `CHANGELOG.md` for notable changes and prepare release sections on request |
 | [`commit`](skills/pac-commit/SKILL.md) | Create, split, or plan commits that follow this repo's branch, staging, and gitmoji workflow |
 | [`github`](skills/pac-github/SKILL.md) | Use the `gh` CLI for issues, PRs, workflow runs, and GitHub API queries |
 | [`github-issue-create`](skills/pac-github-issue-create/SKILL.md) | Create well-formed GitHub issues from inside the current repository |
@@ -130,6 +131,12 @@ Useful first commands:
 
 The hk configuration lints YAML and Markdown files before commit.
 If a check fails, fix the reported file and run the hook again or retry the commit.
+
+### Changelog
+
+- Track notable repository changes in [`CHANGELOG.md`](CHANGELOG.md).
+- For agent-driven work, use [`skills/pac-changelog/SKILL.md`](skills/pac-changelog/SKILL.md) to update `## [Unreleased]` before merge.
+- Keep entries grouped under headings like `Added`, `Changed`, and `Fixed`.
 
 ### Shared resource locations
 

--- a/skills/pac-changelog/SKILL.md
+++ b/skills/pac-changelog/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: pac-changelog
+description: "Update the repository CHANGELOG.md for notable changes and release prep. Use when finishing meaningful work that should be recorded before merge or when preparing a release section."
+license: MIT
+compatibility: Pi coding agent
+metadata:
+  author: mypac
+  stage: shared
+---
+
+# Update the changelog
+
+Use this skill when work in this repository should be recorded in `CHANGELOG.md` before merge or when the user explicitly asks to prepare a release section.
+
+## Goal
+
+Keep `CHANGELOG.md` current as the curated source of notable repository changes.
+
+## Default scope
+
+- Edit `CHANGELOG.md` only unless the user explicitly asks for related docs changes.
+- By default, update `## [Unreleased]`.
+- Prepare a versioned release section only when the user explicitly asks for release prep.
+
+## Entry rules
+
+- Record notable user-facing, workflow-facing, or repository-operating changes.
+- Skip tiny internal edits that would add noise to the changelog.
+- Prefer these headings:
+  - `Added`
+  - `Changed`
+  - `Fixed`
+- Add `Removed` or `Breaking Changes` only when needed.
+- Reuse an existing heading when present instead of creating duplicates.
+- Keep one bullet per distinct change.
+- Match the existing concise style in the file.
+- Link the relevant GitHub issue or pull request when it adds useful context.
+
+## Workflow
+
+### Normal updates
+
+1. Read the current `CHANGELOG.md`.
+2. Check whether the change is notable enough to record.
+3. Update or add the smallest useful bullet under `## [Unreleased]`.
+4. Avoid duplicate or overlapping bullets; merge or rewrite when needed.
+5. Keep the changelog update in the same commit as the work it describes when practical.
+
+### Release prep
+
+When the user explicitly asks to prepare a release:
+
+1. Read the current `CHANGELOG.md`.
+2. Choose the requested version and release date, or ask if either is missing.
+3. Move the relevant bullets out of `## [Unreleased]` into a new section:
+
+   ```md
+   ## [x.y.z] - YYYY-MM-DD
+   ```
+
+4. Keep only the headings that still have entries.
+5. Recreate an empty `## [Unreleased]` section at the top.
+6. Preserve existing older release sections as-is unless the user asks for cleanup.
+7. If helpful, draft GitHub release notes from the new changelog section, but do not publish anything unless the user asks.
+
+## Guardrails
+
+- Do not invent release versions or dates.
+- Do not rewrite older release sections unless the user asks.
+- Do not publish tags or GitHub releases unless the user explicitly asks.
+- Do not turn the changelog into an implementation diary.


### PR DESCRIPTION
Add a repository changelog with an Unreleased section and a small playbook for maintaining it and preparing future GitHub releases.

closes #139
