### PR TITLE
✨ feat(review): Add one-off review instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioned sections should match the Git tags and GitHub releases published for t
 
 ### Changed
 
+- Added one-off optional custom instruction prompts to `/review-start` selector runs and `/review-end` summarize/fix flows, with Enter-to-skip and Esc-to-cancel behavior while keeping `--extra` and shared review instructions unchanged. ([#115](https://github.com/ladislas/mypac/issues/115))
 - Taught `/pac-lwot` to treat linked `## PRDs` and `## Decisions` issue artifacts as first-class planning context, prefer the latest linked PRD iteration, and report which artifacts informed its plan. ([#164](https://github.com/ladislas/mypac/issues/164))
 - Renamed `/review` to `/review-start` and `/end-review` to `/review-end` for a consistent review command pair. ([#108](https://github.com/ladislas/mypac/issues/108))
 - Added a repo-local skill for updating `CHANGELOG.md` during normal agent-driven work and preparing release sections on request. ([#139](https://github.com/ladislas/mypac/issues/139))

--- a/extensions/review/index.test.mjs
+++ b/extensions/review/index.test.mjs
@@ -2,6 +2,87 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import reviewExtension from "./index.ts";
 
+const fakeTheme = {
+	fg: (_color, text) => text,
+	bold: (text) => text,
+};
+const fakeTui = { requestRender() {} };
+
+function submitCustomInput(factory, inputs) {
+	let result;
+	const component = factory(fakeTui, fakeTheme, {}, (value) => {
+		result = value;
+	});
+	for (const input of inputs) {
+		component.handleInput(input);
+	}
+	return result;
+}
+
+function createReviewStartHarness(custom) {
+	const commands = new Map();
+	const notifications = [];
+	const sentMessages = [];
+
+	const pi = {
+		registerCommand(name, definition) {
+			commands.set(name, definition.handler);
+		},
+		on() {},
+		exec: async (command, args) => {
+			if (command === "git" && args[0] === "rev-parse" && args[1] === "--git-dir") {
+				return { code: 0, stdout: ".git\n", stderr: "" };
+			}
+			if (command === "git" && args[0] === "status" && args[1] === "--porcelain") {
+				return { code: 0, stdout: " M extensions/review/index.ts\n", stderr: "" };
+			}
+			throw new Error(`Unexpected exec call: ${command} ${args.join(" ")}`);
+		},
+		appendEntry() {},
+		setSessionName() {},
+		sendUserMessage(message) {
+			sentMessages.push(message);
+		},
+	};
+
+	reviewExtension(pi, {
+		loadPackageSkill: async () => ({ content: "review skill" }),
+	});
+
+	const handler = commands.get("review-start");
+	assert.equal(typeof handler, "function");
+
+	return {
+		handler,
+		notifications,
+		sentMessages,
+		ctx: {
+			hasUI: true,
+			cwd: process.cwd(),
+			sessionManager: {
+				getEntries: () => [{ id: "msg-1", type: "message", message: { role: "user" } }],
+				getBranch: () => [],
+				getLeafId: () => "leaf-1",
+			},
+			navigateTree: async () => {
+				throw new Error("navigateTree should not be called in current-session mode");
+			},
+			ui: {
+				notify(message, level) {
+					notifications.push({ message, level });
+				},
+				setWidget() {},
+				setEditorText() {},
+				custom,
+				select: async (label) => {
+					assert.equal(label, "Start review in:");
+					return "Current session";
+				},
+			},
+		},
+	};
+}
+
 test("/review-start can retry after pac-review skill load failure without leaving active review state", async () => {
 	const commands = new Map();
 	const notifications = [];
@@ -67,4 +148,117 @@ test("/review-start can retry after pac-review skill load failure without leavin
 		{ message: "Could not load skills/pac-review/SKILL.md", level: "error" },
 		{ message: "Could not load skills/pac-review/SKILL.md", level: "error" },
 	]);
+});
+
+test("/review-start selector prompts for an optional one-off instruction", async () => {
+	let customCalls = 0;
+	const { ctx, handler, sentMessages } = createReviewStartHarness(async () => {
+		customCalls += 1;
+		return customCalls === 1
+			? "uncommitted"
+			: { cancelled: false, instruction: "focus on performance regressions" };
+	});
+
+	await handler("", ctx);
+
+	assert.equal(customCalls, 2);
+	assert.equal(sentMessages.length, 1);
+	assert.match(sentMessages[0], /Additional user-provided review instruction:\n\nfocus on performance regressions/);
+});
+
+test("/review-start optional instruction prompt skips on empty enter", async () => {
+	let customCalls = 0;
+	const { ctx, handler, sentMessages } = createReviewStartHarness(async (factory) => {
+		customCalls += 1;
+		return customCalls === 1 ? "uncommitted" : submitCustomInput(factory, ["\n"]);
+	});
+
+	await handler("", ctx);
+
+	assert.equal(customCalls, 2);
+	assert.equal(sentMessages.length, 1);
+	assert.doesNotMatch(sentMessages[0], /Additional user-provided review instruction/);
+});
+
+test("/review-start optional instruction prompt cancels on escape", async () => {
+	let customCalls = 0;
+	const { ctx, handler, notifications, sentMessages } = createReviewStartHarness(async (factory) => {
+		customCalls += 1;
+		return customCalls === 1 ? "uncommitted" : submitCustomInput(factory, ["\x1b"]);
+	});
+
+	await handler("", ctx);
+
+	assert.equal(customCalls, 2);
+	assert.deepEqual(sentMessages, []);
+	assert.deepEqual(notifications, [{ message: "Review cancelled", level: "info" }]);
+});
+
+test("/review-end prompts for an optional one-off instruction before fixing findings", async () => {
+	const commands = new Map();
+	const appendedEntries = [];
+	const sentMessages = [];
+	let customCalls = 0;
+
+	const pi = {
+		registerCommand(name, definition) {
+			commands.set(name, definition.handler);
+		},
+		on() {},
+		appendEntry(customType, data) {
+			appendedEntries.push({ customType, data });
+		},
+		sendUserMessage(message, options) {
+			sentMessages.push({ message, options });
+		},
+	};
+
+	reviewExtension(pi, {
+		loadPackageSkill: async () => ({ content: "review skill" }),
+	});
+
+	const handler = commands.get("review-end");
+	assert.equal(typeof handler, "function");
+
+	const ctx = {
+		hasUI: true,
+		sessionManager: {
+			getEntries: () => [],
+			getBranch: () => [
+				{
+					type: "custom",
+					customType: "review-session",
+					data: { active: true, originId: "origin-1", targetType: "uncommitted" },
+				},
+			],
+			getLeafId: () => "leaf-1",
+		},
+		navigateTree: async () => {
+			throw new Error("navigateTree is driven through the loader in this command test");
+		},
+		ui: {
+			notify() {},
+			setWidget() {},
+			getEditorText: () => "",
+			setEditorText() {},
+			select: async (label) => {
+				assert.equal(label, "Finish review:");
+				return "Summarize + return + fix findings";
+			},
+			custom: async () => {
+				customCalls += 1;
+				return customCalls === 1
+					? { cancelled: false, instruction: "only fix P1 findings" }
+					: { cancelled: false };
+			},
+		},
+	};
+
+	await handler("", ctx);
+
+	assert.equal(customCalls, 2);
+	assert.deepEqual(appendedEntries, [{ customType: "review-session", data: { active: false } }]);
+	assert.equal(sentMessages.length, 1);
+	assert.equal(sentMessages[0].options?.deliverAs, "followUp");
+	assert.match(sentMessages[0].message, /Additional user-provided review instruction:\n\nonly fix P1 findings/);
 });

--- a/extensions/review/index.ts
+++ b/extensions/review/index.ts
@@ -91,6 +91,10 @@ type ReviewSettingsState = {
 	customInstructions?: string;
 };
 
+type OptionalReviewInstructionResult =
+	| { cancelled: true }
+	| { cancelled: false; instruction?: string };
+
 function setReviewWidget(ctx: ExtensionContext, active: boolean) {
 	if (!ctx.hasUI) return;
 	if (!active) {
@@ -404,6 +408,48 @@ export default function reviewExtension(pi: ExtensionAPI, deps: ReviewExtensionD
 	function setReviewCustomInstructions(instructions: string | undefined) {
 		reviewCustomInstructions = instructions?.trim() || undefined;
 		persistReviewSettings();
+	}
+
+	async function promptForOptionalReviewInstruction(ctx: ExtensionContext): Promise<OptionalReviewInstructionResult> {
+		return await ctx.ui.custom<OptionalReviewInstructionResult>((tui, theme, _keybindings, done) => {
+			const container = new Container();
+			container.addChild(new DynamicBorder((str: string) => theme.fg("accent", str)));
+			container.addChild(new Text(theme.fg("accent", theme.bold("Optional: add a custom instruction for this review"))));
+
+			const input = new Input();
+			input.onSubmit = (value) => done({ cancelled: false, instruction: value.trim() || undefined });
+			input.onEscape = () => done({ cancelled: true });
+			container.addChild(input);
+
+			container.addChild(new Text(theme.fg("dim", "Enter empty to skip • enter with text to apply • esc to cancel")));
+			container.addChild(new DynamicBorder((str: string) => theme.fg("accent", str)));
+
+			return {
+				get focused() {
+					return input.focused;
+				},
+				set focused(value: boolean) {
+					input.focused = value;
+				},
+				render(width: number) {
+					return container.render(width);
+				},
+				invalidate() {
+					container.invalidate();
+				},
+				handleInput(data: string) {
+					input.handleInput(data);
+					tui.requestRender();
+				},
+			};
+		});
+	}
+
+	function appendExtraReviewInstruction(prompt: string, extraInstruction: string | undefined): string {
+		const trimmed = extraInstruction?.trim();
+		if (!trimmed) return prompt;
+
+		return `${prompt}\n\nAdditional user-provided review instruction:\n\n${trimmed}`;
 	}
 
 	function applyAllReviewState(ctx: ExtensionContext) {
@@ -991,9 +1037,7 @@ export default function reviewExtension(pi: ExtensionAPI, deps: ReviewExtensionD
 			fullPrompt += `\n\nShared custom review instructions (applies to all reviews):\n\n${reviewCustomInstructions}`;
 		}
 
-		if (options?.extraInstruction?.trim()) {
-			fullPrompt += `\n\nAdditional user-provided review instruction:\n\n${options.extraInstruction.trim()}`;
-		}
+		fullPrompt = appendExtraReviewInstruction(fullPrompt, options?.extraInstruction);
 
 		if (projectGuidelines) {
 			fullPrompt += `\n\nThis project has additional instructions for code reviews:\n\n${projectGuidelines}`;
@@ -1100,6 +1144,15 @@ export default function reviewExtension(pi: ExtensionAPI, deps: ReviewExtensionD
 					useFreshSession = choice === "New session";
 				}
 
+				if (fromSelector && !extraInstruction) {
+					const promptResult = await promptForOptionalReviewInstruction(ctx);
+					if (promptResult.cancelled) {
+						ctx.ui.notify("Review cancelled", "info");
+						return;
+					}
+					extraInstruction = promptResult.instruction;
+				}
+
 				await executeReview(ctx, target, useFreshSession, { extraInstruction });
 				return;
 			}
@@ -1155,6 +1208,7 @@ Preserve exact file paths, function names, and error messages where available.`;
 	type EndReviewActionOptions = {
 		showSummaryLoader?: boolean;
 		notifySuccess?: boolean;
+		extraInstruction?: string;
 	};
 
 	function getActiveReviewOrigin(ctx: ExtensionContext): string | undefined {
@@ -1187,7 +1241,10 @@ Preserve exact file paths, function names, and error messages where available.`;
 		ctx: ExtensionCommandContext,
 		originId: string,
 		showLoader: boolean,
+		extraInstruction?: string,
 	): Promise<{ cancelled: boolean; error?: string } | null> {
+		const summaryPrompt = appendExtraReviewInstruction(REVIEW_SUMMARY_PROMPT, extraInstruction);
+
 		if (showLoader && ctx.hasUI) {
 			return ctx.ui.custom<{ cancelled: boolean; error?: string } | null>((tui, theme, _kb, done) => {
 				const loader = new BorderedLoader(tui, theme, "Returning and summarizing review session...");
@@ -1195,7 +1252,7 @@ Preserve exact file paths, function names, and error messages where available.`;
 
 				ctx.navigateTree(originId, {
 					summarize: true,
-					customInstructions: REVIEW_SUMMARY_PROMPT,
+					customInstructions: summaryPrompt,
 					replaceInstructions: true,
 				})
 					.then(done)
@@ -1208,7 +1265,7 @@ Preserve exact file paths, function names, and error messages where available.`;
 		try {
 			return await ctx.navigateTree(originId, {
 				summarize: true,
-				customInstructions: REVIEW_SUMMARY_PROMPT,
+				customInstructions: summaryPrompt,
 				replaceInstructions: true,
 			});
 		} catch (error) {
@@ -1251,7 +1308,12 @@ Preserve exact file paths, function names, and error messages where available.`;
 			return "ok";
 		}
 
-		const summaryResult = await navigateWithSummary(ctx, originId, options.showSummaryLoader ?? false);
+		const summaryResult = await navigateWithSummary(
+			ctx,
+			originId,
+			options.showSummaryLoader ?? false,
+			options.extraInstruction,
+		);
 		if (summaryResult === null) {
 			ctx.ui.notify("Summarization cancelled. Use /review-end to try again.", "info");
 			return "cancelled";
@@ -1279,7 +1341,11 @@ Preserve exact file paths, function names, and error messages where available.`;
 			return "ok";
 		}
 
-		pi.sendUserMessage(buildReviewFixFindingsPrompt(reviewTargetType), { deliverAs: "followUp" });
+		const fixPrompt = appendExtraReviewInstruction(
+			buildReviewFixFindingsPrompt(reviewTargetType),
+			options.extraInstruction,
+		);
+		pi.sendUserMessage(fixPrompt, { deliverAs: "followUp" });
 		if (notifySuccess) {
 			ctx.ui.notify("Review complete! Returned and queued a follow-up to fix findings.", "info");
 		}
@@ -1320,9 +1386,20 @@ Preserve exact file paths, function names, and error messages where available.`;
 				return;
 			}
 
+			let extraInstruction: string | undefined;
+			if (action !== "returnOnly") {
+				const promptResult = await promptForOptionalReviewInstruction(ctx);
+				if (promptResult.cancelled) {
+					ctx.ui.notify("Cancelled. Use /review-end to try again.", "info");
+					return;
+				}
+				extraInstruction = promptResult.instruction;
+			}
+
 			await executeEndReviewAction(ctx, action, {
 				showSummaryLoader: true,
 				notifySuccess: true,
+				extraInstruction,
 			});
 		} finally {
 			endReviewInProgress = false;


### PR DESCRIPTION
Prompt for optional per-review instructions in /review-start selector flows and /review-end summarize/fix flows while preserving --extra and shared custom review instructions.

closes #115
