### PR TITLE
✨ feat(review): Harden Markdown prompt loading

### DIFF
--- a/extensions/review/helpers.test.mjs
+++ b/extensions/review/helpers.test.mjs
@@ -12,6 +12,12 @@ const reviewFixFindingsTemplate = readFileSync(
 	"utf8",
 ).replace(/^# .+\n+/, "").trim();
 
+function getPromptPlaceholders(template) {
+	return [...template.matchAll(/{{\s*([^{}\s]+)\s*}}/g)]
+		.map((match) => match[1])
+		.sort();
+}
+
 // ─── parseArgs ────────────────────────────────────────────────────────────────
 
 test("parseArgs: empty → null target", () => {
@@ -102,4 +108,29 @@ test("buildReviewFixFindingsPrompt: unknown review mode defaults to staging work
 	assert.match(prompt, /original review mode is unavailable/i);
 	assert.match(prompt, /\*\*Staging workflow:\*\*/);
 	assert.doesNotMatch(prompt, /\*\*Fixup workflow:\*\*/);
+});
+
+test("buildReviewFixFindingsPrompt: expected template placeholders stay covered", () => {
+	assert.deepEqual(getPromptPlaceholders(reviewFixFindingsTemplate), [
+		"commitDisciplineIntro",
+		"nextStepInstruction",
+		"preparedChangesLabel",
+		"preparedItemLabel",
+		"preparedItemTargetDetail",
+		"workflowInstructions",
+	]);
+});
+
+test("buildReviewFixFindingsPrompt: supported workflows render without unresolved placeholders", () => {
+	for (const targetType of [undefined, "uncommitted", "baseBranch", "commit", "pullRequest", "folder"]) {
+		const prompt = buildReviewFixFindingsPrompt(reviewFixFindingsTemplate, targetType);
+		assert.doesNotMatch(prompt, /{{\s*[^{}\s]+\s*}}/, `target type: ${targetType ?? "unknown"}`);
+	}
+});
+
+test("buildReviewFixFindingsPrompt: unresolved template placeholders fail loudly", () => {
+	assert.throws(
+		() => buildReviewFixFindingsPrompt(`${reviewFixFindingsTemplate}\n\n{{newPlaceholder}}`, "uncommitted"),
+		/Unresolved prompt template placeholder\(s\): {{newPlaceholder}}/,
+	);
 });

--- a/extensions/review/helpers.ts
+++ b/extensions/review/helpers.ts
@@ -17,6 +17,8 @@ export type ParsedReviewArgs = {
 
 export type ReviewFixWorkflow = "fixup" | "staged";
 
+const UNRESOLVED_PROMPT_PLACEHOLDER_PATTERN = /{{\s*[^{}\s]+\s*}}/g;
+
 // ─── Prompt templates ─────────────────────────────────────────────────────────
 
 export const UNCOMMITTED_PROMPT =
@@ -72,6 +74,12 @@ function renderPromptTemplate(template: string, values: Record<string, string>):
 	for (const [key, value] of Object.entries(values)) {
 		prompt = prompt.replaceAll(`{{${key}}}`, () => value);
 	}
+
+	const unresolvedPlaceholders = prompt.match(UNRESOLVED_PROMPT_PLACEHOLDER_PATTERN);
+	if (unresolvedPlaceholders) {
+		throw new Error(`Unresolved prompt template placeholder(s): ${[...new Set(unresolvedPlaceholders)].join(", ")}`);
+	}
+
 	return prompt.trim();
 }
 

--- a/extensions/review/index.test.mjs
+++ b/extensions/review/index.test.mjs
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import reviewExtension from "./index.ts";
+import { ReviewPromptLoadError } from "./prompts.ts";
 
 const fakeTheme = {
 	fg: (_color, text) => text,
@@ -261,4 +262,77 @@ test("/review-end prompts for an optional one-off instruction before fixing find
 	assert.equal(sentMessages.length, 1);
 	assert.equal(sentMessages[0].options?.deliverAs, "followUp");
 	assert.match(sentMessages[0].message, /Additional user-provided review instruction:\n\nonly fix P1 findings/);
+});
+
+test("/review-end reports Markdown prompt load failures as review extension errors", async () => {
+	const commands = new Map();
+	const appendedEntries = [];
+	const notifications = [];
+	const sentMessages = [];
+
+	const pi = {
+		registerCommand(name, definition) {
+			commands.set(name, definition.handler);
+		},
+		on() {},
+		appendEntry(customType, data) {
+			appendedEntries.push({ customType, data });
+		},
+		sendUserMessage(message, options) {
+			sentMessages.push({ message, options });
+		},
+	};
+
+	reviewExtension(pi, {
+		loadReviewSummaryPrompt: async () => {
+			throw new ReviewPromptLoadError(
+				"review summary",
+				"/missing/REVIEW_SUMMARY_PROMPT.md",
+				new Error("ENOENT: no such file or directory"),
+			);
+		},
+	});
+
+	const handler = commands.get("review-end");
+	assert.equal(typeof handler, "function");
+
+	const ctx = {
+		hasUI: true,
+		sessionManager: {
+			getEntries: () => [],
+			getBranch: () => [
+				{
+					type: "custom",
+					customType: "review-session",
+					data: { active: true, originId: "origin-1", targetType: "uncommitted" },
+				},
+			],
+			getLeafId: () => "leaf-1",
+		},
+		navigateTree: async () => {
+			throw new Error("navigateTree should not be called when prompt loading fails");
+		},
+		ui: {
+			notify(message, level) {
+				notifications.push({ message, level });
+			},
+			setWidget() {},
+			getEditorText: () => "",
+			setEditorText() {},
+			select: async (label) => {
+				assert.equal(label, "Finish review:");
+				return "Summarize + return";
+			},
+			custom: async () => ({ cancelled: false }),
+		},
+	};
+
+	await handler("", ctx);
+
+	assert.deepEqual(appendedEntries, []);
+	assert.deepEqual(sentMessages, []);
+	assert.equal(notifications.length, 1);
+	assert.equal(notifications[0].level, "error");
+	assert.match(notifications[0].message, /Review extension failed to load review summary Markdown prompt/);
+	assert.match(notifications[0].message, /REVIEW_SUMMARY_PROMPT\.md/);
 });

--- a/extensions/review/index.ts
+++ b/extensions/review/index.ts
@@ -45,8 +45,12 @@ import {
 } from "@mariozechner/pi-tui";
 import path from "node:path";
 import { promises as fs } from "node:fs";
-import { fileURLToPath } from "node:url";
 import { loadPackageSkill } from "../../lib/skill-loader.ts";
+import {
+	formatReviewPromptError,
+	loadReviewFixFindingsPrompt as defaultLoadReviewFixFindingsPrompt,
+	loadReviewSummaryPrompt as defaultLoadReviewSummaryPrompt,
+} from "./prompts.ts";
 import {
 	type ReviewTarget,
 	UNCOMMITTED_PROMPT,
@@ -65,27 +69,6 @@ import {
 	buildReviewFixFindingsPrompt,
 } from "./helpers.ts";
 
-const currentDir = path.dirname(fileURLToPath(import.meta.url));
-const reviewSummaryPromptPath = path.join(currentDir, "REVIEW_SUMMARY_PROMPT.md");
-const reviewFixFindingsPromptPath = path.join(currentDir, "REVIEW_FIX_FINDINGS_PROMPT.md");
-
-let reviewSummaryPrompt: string | undefined;
-let reviewFixFindingsPrompt: string | undefined;
-
-function stripPromptMarkdownTitle(prompt: string): string {
-	return prompt.replace(/^# .+\n+/, "").trim();
-}
-
-async function loadReviewSummaryPrompt(): Promise<string> {
-	reviewSummaryPrompt ??= stripPromptMarkdownTitle(await fs.readFile(reviewSummaryPromptPath, "utf8"));
-	return reviewSummaryPrompt;
-}
-
-async function loadReviewFixFindingsPrompt(): Promise<string> {
-	reviewFixFindingsPrompt ??= stripPromptMarkdownTitle(await fs.readFile(reviewFixFindingsPromptPath, "utf8"));
-	return reviewFixFindingsPrompt;
-}
-
 // State to track fresh-session review origin (where we started from).
 // Module-level state means only one review can be active at a time.
 // This is intentional - the UI and /review-end command assume a single active review.
@@ -101,6 +84,8 @@ const PR_CHECKOUT_BLOCKED_BY_PENDING_CHANGES_MESSAGE =
 
 type ReviewExtensionDeps = {
 	loadPackageSkill?: typeof loadPackageSkill;
+	loadReviewSummaryPrompt?: typeof defaultLoadReviewSummaryPrompt;
+	loadReviewFixFindingsPrompt?: typeof defaultLoadReviewFixFindingsPrompt;
 };
 
 type ReviewSessionState = {
@@ -420,6 +405,8 @@ type ReviewPresetValue =
 
 export default function reviewExtension(pi: ExtensionAPI, deps: ReviewExtensionDeps = {}) {
 	const loadSkill = deps.loadPackageSkill ?? loadPackageSkill;
+	const loadReviewSummaryPrompt = deps.loadReviewSummaryPrompt ?? defaultLoadReviewSummaryPrompt;
+	const loadReviewFixFindingsPrompt = deps.loadReviewFixFindingsPrompt ?? defaultLoadReviewFixFindingsPrompt;
 
 	function persistReviewSettings() {
 		pi.appendEntry(REVIEW_SETTINGS_TYPE, {
@@ -1287,12 +1274,18 @@ export default function reviewExtension(pi: ExtensionAPI, deps: ReviewExtensionD
 			return "ok";
 		}
 
-		const summaryResult = await navigateWithSummary(
-			ctx,
-			originId,
-			options.showSummaryLoader ?? false,
-			options.extraInstruction,
-		);
+		let summaryResult: { cancelled: boolean; error?: string } | null;
+		try {
+			summaryResult = await navigateWithSummary(
+				ctx,
+				originId,
+				options.showSummaryLoader ?? false,
+				options.extraInstruction,
+			);
+		} catch (error) {
+			ctx.ui.notify(formatReviewPromptError(error), "error");
+			return "error";
+		}
 		if (summaryResult === null) {
 			ctx.ui.notify("Summarization cancelled. Use /review-end to try again.", "info");
 			return "cancelled";
@@ -1320,11 +1313,17 @@ export default function reviewExtension(pi: ExtensionAPI, deps: ReviewExtensionD
 			return "ok";
 		}
 
-		const fixFindingsTemplate = await loadReviewFixFindingsPrompt();
-		const fixPrompt = appendExtraReviewInstruction(
-			buildReviewFixFindingsPrompt(fixFindingsTemplate, reviewTargetType),
-			options.extraInstruction,
-		);
+		let fixPrompt: string;
+		try {
+			const fixFindingsTemplate = await loadReviewFixFindingsPrompt();
+			fixPrompt = appendExtraReviewInstruction(
+				buildReviewFixFindingsPrompt(fixFindingsTemplate, reviewTargetType),
+				options.extraInstruction,
+			);
+		} catch (error) {
+			ctx.ui.notify(formatReviewPromptError(error), "error");
+			return "error";
+		}
 		pi.sendUserMessage(fixPrompt, { deliverAs: "followUp" });
 		if (notifySuccess) {
 			ctx.ui.notify("Review complete! Returned and queued a follow-up to fix findings.", "info");

--- a/extensions/review/prompts.test.mjs
+++ b/extensions/review/prompts.test.mjs
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+	loadMarkdownReviewPrompt,
+	ReviewPromptLoadError,
+	stripPromptMarkdownTitle,
+} from "./prompts.ts";
+
+test("stripPromptMarkdownTitle removes a single Markdown title", () => {
+	assert.equal(stripPromptMarkdownTitle("# Prompt Title\n\nBody"), "Body");
+});
+
+test("loadMarkdownReviewPrompt returns stripped prompt content", async () => {
+	const dir = await mkdtemp(path.join(tmpdir(), "review-prompts-"));
+	try {
+		const promptPath = path.join(dir, "PROMPT.md");
+		await writeFile(promptPath, "# Test Prompt\n\nPrompt body\n", "utf8");
+
+		assert.equal(await loadMarkdownReviewPrompt("test", promptPath), "Prompt body");
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test("loadMarkdownReviewPrompt reports missing Markdown prompt files clearly", async () => {
+	const missingPath = path.join(tmpdir(), "missing-review-prompt.md");
+
+	await assert.rejects(
+		() => loadMarkdownReviewPrompt("test", missingPath),
+		(error) => {
+			assert.ok(error instanceof ReviewPromptLoadError);
+			assert.match(error.message, /Review extension failed to load test Markdown prompt/);
+			assert.match(error.message, /missing-review-prompt\.md/);
+			return true;
+		},
+	);
+});

--- a/extensions/review/prompts.ts
+++ b/extensions/review/prompts.ts
@@ -1,0 +1,56 @@
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const reviewSummaryPromptPath = path.join(currentDir, "REVIEW_SUMMARY_PROMPT.md");
+const reviewFixFindingsPromptPath = path.join(currentDir, "REVIEW_FIX_FINDINGS_PROMPT.md");
+
+let reviewSummaryPrompt: string | undefined;
+let reviewFixFindingsPrompt: string | undefined;
+
+export class ReviewPromptLoadError extends Error {
+	readonly cause: unknown;
+
+	constructor(promptLabel: string, promptPath: string, cause: unknown) {
+		super(`Review extension failed to load ${promptLabel} Markdown prompt at ${promptPath}: ${formatCause(cause)}`);
+		this.name = "ReviewPromptLoadError";
+		this.cause = cause;
+	}
+}
+
+function formatCause(cause: unknown): string {
+	if (cause instanceof Error) {
+		return cause.message;
+	}
+	return String(cause);
+}
+
+export function formatReviewPromptError(error: unknown): string {
+	if (error instanceof ReviewPromptLoadError) {
+		return error.message;
+	}
+	return `Review extension failed to prepare a Markdown prompt: ${formatCause(error)}`;
+}
+
+export function stripPromptMarkdownTitle(prompt: string): string {
+	return prompt.replace(/^# .+\n+/, "").trim();
+}
+
+export async function loadMarkdownReviewPrompt(promptLabel: string, promptPath: string): Promise<string> {
+	try {
+		return stripPromptMarkdownTitle(await fs.readFile(promptPath, "utf8"));
+	} catch (error) {
+		throw new ReviewPromptLoadError(promptLabel, promptPath, error);
+	}
+}
+
+export async function loadReviewSummaryPrompt(): Promise<string> {
+	reviewSummaryPrompt ??= await loadMarkdownReviewPrompt("review summary", reviewSummaryPromptPath);
+	return reviewSummaryPrompt;
+}
+
+export async function loadReviewFixFindingsPrompt(): Promise<string> {
+	reviewFixFindingsPrompt ??= await loadMarkdownReviewPrompt("review fix-findings", reviewFixFindingsPromptPath);
+	return reviewFixFindingsPrompt;
+}


### PR DESCRIPTION
Move review Markdown prompt loading into a colocated helper module, fail fix-finding prompt rendering when unresolved placeholders remain, and add focused coverage for prompt templates and load failures.

closes #187
