### PR TITLE
🔧 chore(copilot): Add PR review instructions

### DIFF
--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -1,0 +1,88 @@
+---
+applyTo: "**"
+excludeAgent: "cloud-agent"
+---
+
+# Copilot code review instructions for mypac
+
+These instructions adapt this repository's local Pi review rubric from
+`skills/pac-review/SKILL.md`. Apply them when reviewing pull requests in this
+repository.
+
+## Pull request review policy
+
+Act as a high-signal code reviewer. Flag issues only when they meet all of these
+conditions:
+
+- The issue was introduced by the pull request diff.
+- The issue meaningfully affects correctness, security, performance, or
+  maintainability.
+- The issue is discrete, actionable, and likely worth fixing.
+- The impact is tied to code or behavior in this repository, not speculation.
+- The finding does not depend on unstated assumptions about the author's intent.
+
+Do not flag trivial style issues unless they obscure meaning or violate a
+repository standard. Prefer simple, direct fixes over new wrappers or abstractions
+without clear value.
+
+## Security and untrusted input
+
+Review untrusted input paths carefully. In particular:
+
+- Flag SQL or query construction that is not parameterized.
+- Flag redirects that do not restrict destinations to trusted domains.
+- Flag server-side fetches of user-supplied URLs that can reach local or private
+  network resources.
+- Prefer escaping over sanitizing when outputting untrusted content.
+
+## Error handling and fallback behavior
+
+Default to fail-fast error handling. Treat silent recovery as a high-signal review
+candidate unless there is explicit boundary-level justification.
+
+When reviewing added or modified `try`/`catch` blocks, check what can fail and
+whether the current layer can really recover while preserving correctness. Flag
+catch blocks that swallow errors, log and continue, return fallback values such
+as `null`, `[]`, or `false`, or quietly ignore JSON parsing/decoding failures.
+Boundary handlers may translate errors, but they must not pretend success or
+silently degrade.
+
+## Comment style
+
+When leaving review comments:
+
+- Start each finding heading or first line with a priority tag: `[P0]`,
+  `[P1]`, `[P2]`, or `[P3]`.
+- Keep each finding concise and focused on one issue.
+- Explain why the issue matters and when it occurs.
+- Reference lines changed by the pull request whenever possible.
+- Use suggestion blocks only for concrete replacement code.
+- Avoid excessive praise, hedging, or accusatory language.
+
+Priority meanings:
+
+- `[P0]`: release- or operations-blocking issue that needs immediate attention.
+- `[P1]`: urgent issue that should be fixed in the next cycle.
+- `[P2]`: normal issue that should be fixed eventually.
+- `[P3]`: low-priority improvement that is still worth considering.
+
+## Human reviewer callouts
+
+At the end of a summary-style PR review, always include a section named
+`Human Reviewer Callouts (Non-Blocking)`. If no callouts apply, write exactly
+`- (none)`.
+
+When a callout applies, use the matching bullet prefix exactly and include only
+applicable callouts:
+
+```markdown
+- **This change adds a database migration:** <files/details>
+- **This change introduces a new dependency:** <package(s)/details>
+- **This change changes a dependency (or the lockfile):** <files/package(s)/details>
+- **This change modifies auth/permission behavior:** <what changed and where>
+- **This change introduces backwards-incompatible public schema/API/contract changes:** <what changed and where>
+- **This change includes irreversible or destructive operations:** <operation and scope>
+```
+
+These callouts are informational for the human reviewer. Do not treat them as
+blocking findings unless there is an independent defect.


### PR DESCRIPTION
## Summary

- add Copilot code-review-specific instructions under `.github/instructions/code-review.instructions.md`
- adapt the local Pi review rubric from `skills/pac-review/SKILL.md`
- scope the rubric to Copilot code review with `applyTo: "**"` and `excludeAgent: "cloud-agent"`

## Manual setup / validation

- GitHub Copilot code review supports `.github/instructions/**/*.instructions.md` custom instructions.
- For Copilot code review, the user's personal setting for repository custom instructions must be enabled; GitHub docs say this is enabled by default.
- Validate by requesting Copilot review on this PR and checking that review comments follow the rubric, especially `[P#]` priority tags and human reviewer callouts.

## Verification

- `git diff --check`
- `npx markdownlint-cli2 .github/instructions/code-review.instructions.md`
- pre-commit hooks during commit, including `markdownlint-cli2`

refs #74
