### PR TITLE
✨ feat(github): Add pac label health workflow

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -9,9 +9,9 @@ jobs:
   bootstrap-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/pac-label-health.yml
+++ b/.github/workflows/pac-label-health.yml
@@ -1,0 +1,39 @@
+name: Pac label health
+
+on:
+  issues:
+    types: [opened, reopened, edited, labeled, unlabeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to check
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: pac-label-health-${{ github.repository }}-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.number || inputs.issue_number }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - run: npm ci
+
+      - name: Check pac issue labels
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+        run: node --experimental-strip-types scripts/pac-label-health.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioned sections should match the Git tags and GitHub releases published for t
 - Added `/pac-zoom-out` as a lightweight prompt for mapping a code area without creating a full skill. ([#195](https://github.com/ladislas/mypac/issues/195))
 - Added `pac-triage`, its thin `/pac-triage` prompt, durable agent-brief guidance, GitHub-first wontfix handling, and `out of scope` scope-boundary comments. ([#196](https://github.com/ladislas/mypac/issues/196))
 - Added `/pac-setup-workflows` to check and explicitly apply canonical `pac:*` GitHub workflow labels, including legacy label migration planning. ([#199](https://github.com/ladislas/mypac/issues/199))
+- Added a pac label-health GitHub Actions workflow that maintains one managed warning comment for conflicting or drifted issue workflow labels. ([#203](https://github.com/ladislas/mypac/issues/203))
 
 ### Changed
 

--- a/scripts/pac-label-health.test.mjs
+++ b/scripts/pac-label-health.test.mjs
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { REQUIRED_PAC_LABELS } from "../extensions/pac-setup-workflows/config.ts";
+import {
+	MANAGED_COMMENT_MARKER,
+	analyzeIssueLabelHealth,
+	reconcileManagedComment,
+	renderWarningComment,
+} from "./pac-label-health.ts";
+
+const repositoryLabels = REQUIRED_PAC_LABELS.map((label) => ({ ...label }));
+
+function analyze(issueLabels, labels = repositoryLabels) {
+	return analyzeIssueLabelHealth({ issueLabels, repositoryLabels: labels });
+}
+
+test("analyzeIssueLabelHealth accepts one state and one execution label", () => {
+	const result = analyze(["pac:ready_for_agent", "pac:afk", "pac:prd"]);
+
+	assert.deepEqual(result.problems, []);
+});
+
+test("analyzeIssueLabelHealth detects conflicting state labels", () => {
+	const result = analyze(["pac:needs_triage", "pac:ready_for_agent"]);
+
+	assert.equal(result.problems[0].kind, "conflicting-state");
+	assert.match(result.problems[0].message, /pac:needs_triage/);
+	assert.match(result.problems[0].message, /pac:ready_for_agent/);
+});
+
+test("analyzeIssueLabelHealth detects conflicting execution labels", () => {
+	const result = analyze(["pac:hitl", "pac:afk"]);
+
+	assert.equal(result.problems[0].kind, "conflicting-execution");
+});
+
+test("analyzeIssueLabelHealth detects legacy labels", () => {
+	const result = analyze(["needs triage", "prd"]);
+
+	assert.deepEqual(
+		result.problems.filter((problem) => problem.kind === "legacy-label").map((problem) => problem.message),
+		[
+			"Legacy label `needs triage` is present. Replace it with `pac:needs_triage`.",
+			"Legacy label `prd` is present. Replace it with `pac:prd`.",
+		],
+	);
+});
+
+test("analyzeIssueLabelHealth detects required label setup drift", () => {
+	const labels = repositoryLabels.map((label) =>
+		label.name === "pac:prd" ? { ...label, color: "C5DEF5", description: "old description" } : label,
+	);
+	const result = analyze(["pac:prd"], labels);
+
+	assert.equal(result.problems.length, 1);
+	assert.equal(result.problems[0].kind, "drifted-required-label");
+	assert.match(result.problems[0].message, /pac:prd/);
+	assert.match(result.problems[0].message, /color #C5DEF5 should be #BFDADC/);
+});
+
+test("analyzeIssueLabelHealth detects missing required labels", () => {
+	const labels = repositoryLabels.filter((label) => label.name !== "pac:afk");
+	const result = analyze([], labels);
+
+	assert.equal(result.problems.length, 1);
+	assert.equal(result.problems[0].kind, "missing-required-label");
+	assert.match(result.problems[0].message, /pac:afk/);
+});
+
+test("renderWarningComment includes the managed marker and problem list", () => {
+	const body = renderWarningComment({
+		problems: [{ kind: "legacy-label", message: "Legacy label `prd` is present." }],
+	});
+
+	assert.match(body, new RegExp(MANAGED_COMMENT_MARKER));
+	assert.match(body, /Pac label-health warning/);
+	assert.match(body, /Legacy label `prd` is present\./);
+});
+
+test("reconcileManagedComment creates a managed comment when problems exist", async () => {
+	const calls = [];
+	const action = await reconcileManagedComment({
+		issueNumber: 203,
+		result: { problems: [{ kind: "conflicting-execution", message: "bad labels" }] },
+		client: {
+			async fetchComments() {
+				return [];
+			},
+			async createComment(issueNumber, body) {
+				calls.push(["create", issueNumber, body]);
+			},
+			async updateComment() {
+				throw new Error("unexpected update");
+			},
+			async deleteComment() {
+				throw new Error("unexpected delete");
+			},
+		},
+	});
+
+	assert.equal(action, "created");
+	assert.equal(calls[0][0], "create");
+	assert.equal(calls[0][1], 203);
+	assert.match(calls[0][2], /bad labels/);
+});
+
+test("reconcileManagedComment deletes a managed comment when problems are fixed", async () => {
+	const calls = [];
+	const action = await reconcileManagedComment({
+		issueNumber: 203,
+		result: { problems: [] },
+		client: {
+			async fetchComments() {
+				return [{ id: 1, body: `${MANAGED_COMMENT_MARKER}\nold warning` }];
+			},
+			async createComment() {
+				throw new Error("unexpected create");
+			},
+			async updateComment() {
+				throw new Error("unexpected update");
+			},
+			async deleteComment(commentId) {
+				calls.push(["delete", commentId]);
+			},
+		},
+	});
+
+	assert.equal(action, "deleted");
+	assert.deepEqual(calls, [["delete", 1]]);
+});

--- a/scripts/pac-label-health.ts
+++ b/scripts/pac-label-health.ts
@@ -1,0 +1,263 @@
+import { fileURLToPath } from "node:url";
+
+import { LEGACY_LABEL_MAPPINGS, REQUIRED_PAC_LABELS } from "../extensions/pac-setup-workflows/config.ts";
+import type { GitHubLabel, LabelSpec } from "../extensions/pac-setup-workflows/types.ts";
+
+export const MANAGED_COMMENT_MARKER = "<!-- pac:label-health -->";
+
+const PAC_STATE_LABELS = new Set([
+	"pac:needs_triage",
+	"pac:needs_info",
+	"pac:ready_for_agent",
+	"pac:ready_for_human",
+	"pac:out_of_scope",
+	"pac:wontfix",
+]);
+
+const EXECUTION_LABELS = new Set(["pac:hitl", "pac:afk"]);
+
+type IssueComment = {
+	id: number;
+	body?: string;
+};
+
+export type LabelHealthProblem = {
+	kind: "conflicting-state" | "conflicting-execution" | "legacy-label" | "missing-required-label" | "drifted-required-label";
+	message: string;
+};
+
+export type LabelHealthInput = {
+	issueLabels: string[];
+	repositoryLabels: GitHubLabel[];
+};
+
+export type LabelHealthResult = {
+	problems: LabelHealthProblem[];
+};
+
+export function normalizeColor(color: string): string {
+	return color.replace(/^#/, "").toUpperCase();
+}
+
+function labelKey(name: string): string {
+	return name.toLowerCase();
+}
+
+function formatLabelList(labels: string[]): string {
+	return labels.map((label) => `\`${label}\``).join(", ");
+}
+
+export function analyzeIssueLabelHealth(input: LabelHealthInput): LabelHealthResult {
+	const issueLabelNames = new Set(input.issueLabels.map(labelKey));
+	const repositoryLabels = new Map(input.repositoryLabels.map((label) => [labelKey(label.name), label]));
+	const problems: LabelHealthProblem[] = [];
+
+	const presentStateLabels = [...PAC_STATE_LABELS].filter((label) => issueLabelNames.has(labelKey(label)));
+	if (presentStateLabels.length > 1) {
+		problems.push({
+			kind: "conflicting-state",
+			message: `Conflicting pac state/terminal labels are present: ${formatLabelList(presentStateLabels)}. Keep exactly one workflow state or terminal outcome label.`,
+		});
+	}
+
+	const presentExecutionLabels = [...EXECUTION_LABELS].filter((label) => issueLabelNames.has(labelKey(label)));
+	if (presentExecutionLabels.length > 1) {
+		problems.push({
+			kind: "conflicting-execution",
+			message: `Conflicting pac execution labels are present: ${formatLabelList(presentExecutionLabels)}. Choose either \`pac:hitl\` or \`pac:afk\`, not both.`,
+		});
+	}
+
+	for (const mapping of LEGACY_LABEL_MAPPINGS) {
+		if (issueLabelNames.has(labelKey(mapping.legacy))) {
+			problems.push({
+				kind: "legacy-label",
+				message: `Legacy label \`${mapping.legacy}\` is present. Replace it with \`${mapping.target}\`.`,
+			});
+		}
+	}
+
+	for (const expected of REQUIRED_PAC_LABELS) {
+		const actual = repositoryLabels.get(labelKey(expected.name));
+		if (!actual) {
+			problems.push({
+				kind: "missing-required-label",
+				message: `Required pac workflow label \`${expected.name}\` is missing from the repository. Run \`/pac-setup-workflows\`.`,
+			});
+			continue;
+		}
+
+		const drift: string[] = [];
+		if (normalizeColor(actual.color) !== normalizeColor(expected.color)) {
+			drift.push(`color #${normalizeColor(actual.color)} should be #${normalizeColor(expected.color)}`);
+		}
+		if ((actual.description ?? "") !== expected.description) {
+			drift.push(`description should be "${expected.description}"`);
+		}
+		if (drift.length > 0) {
+			problems.push({
+				kind: "drifted-required-label",
+				message: `Required pac workflow label \`${expected.name}\` has setup drift: ${drift.join("; ")}. Run \`/pac-setup-workflows\`.`,
+			});
+		}
+	}
+
+	return { problems };
+}
+
+export function renderWarningComment(result: LabelHealthResult): string {
+	const lines = [
+		MANAGED_COMMENT_MARKER,
+		"## Pac label-health warning",
+		"",
+		"This issue currently has pac workflow label problems:",
+		"",
+		...result.problems.map((problem) => `- ${problem.message}`),
+		"",
+		"Fix the labels, then the managed warning will be removed automatically on the next label-health run.",
+	];
+
+	return lines.join("\n");
+}
+
+class GitHubClient {
+	private readonly repository: string;
+	private readonly token: string;
+	private readonly apiUrl: string;
+
+	constructor(repository: string, token: string, apiUrl = "https://api.github.com") {
+		this.repository = repository;
+		this.token = token;
+		this.apiUrl = apiUrl;
+	}
+
+	private async request<T>(path: string, init: RequestInit = {}): Promise<T> {
+		const response = await fetch(`${this.apiUrl}${path}`, {
+			...init,
+			headers: {
+				accept: "application/vnd.github+json",
+				authorization: `Bearer ${this.token}`,
+				"x-github-api-version": "2022-11-28",
+				...init.headers,
+			},
+		});
+
+		if (!response.ok) {
+			const body = await response.text();
+			throw new Error(`GitHub API ${init.method ?? "GET"} ${path} failed: ${response.status} ${body}`);
+		}
+
+		if (response.status === 204) {
+			return undefined as T;
+		}
+
+		return (await response.json()) as T;
+	}
+
+	async fetchIssueLabels(issueNumber: number): Promise<string[]> {
+		const issue = await this.request<{ labels: Array<string | { name: string }> }>(`/repos/${this.repository}/issues/${issueNumber}`);
+		return issue.labels.map((label) => (typeof label === "string" ? label : label.name));
+	}
+
+	async fetchRepositoryLabels(): Promise<GitHubLabel[]> {
+		const labels: GitHubLabel[] = [];
+		let page = 1;
+
+		while (true) {
+			const pageLabels = await this.request<GitHubLabel[]>(`/repos/${this.repository}/labels?per_page=100&page=${page}`);
+			labels.push(...pageLabels);
+			if (pageLabels.length < 100) break;
+			page += 1;
+		}
+
+		return labels;
+	}
+
+	async fetchComments(issueNumber: number): Promise<IssueComment[]> {
+		const comments: IssueComment[] = [];
+		let page = 1;
+
+		while (true) {
+			const pageComments = await this.request<IssueComment[]>(
+				`/repos/${this.repository}/issues/${issueNumber}/comments?per_page=100&page=${page}`,
+			);
+			comments.push(...pageComments);
+			if (pageComments.length < 100) break;
+			page += 1;
+		}
+
+		return comments;
+	}
+
+	async createComment(issueNumber: number, body: string): Promise<void> {
+		await this.request(`/repos/${this.repository}/issues/${issueNumber}/comments`, {
+			method: "POST",
+			body: JSON.stringify({ body }),
+		});
+	}
+
+	async updateComment(commentId: number, body: string): Promise<void> {
+		await this.request(`/repos/${this.repository}/issues/comments/${commentId}`, {
+			method: "PATCH",
+			body: JSON.stringify({ body }),
+		});
+	}
+
+	async deleteComment(commentId: number): Promise<void> {
+		await this.request(`/repos/${this.repository}/issues/comments/${commentId}`, { method: "DELETE" });
+	}
+}
+
+export async function reconcileManagedComment(options: {
+	client: Pick<GitHubClient, "fetchComments" | "createComment" | "updateComment" | "deleteComment">;
+	issueNumber: number;
+	result: LabelHealthResult;
+}): Promise<"created" | "updated" | "deleted" | "unchanged"> {
+	const comments = await options.client.fetchComments(options.issueNumber);
+	const managedComments = comments.filter((comment) => comment.body?.includes(MANAGED_COMMENT_MARKER));
+	const [firstManagedComment, ...extraManagedComments] = managedComments;
+
+	for (const comment of extraManagedComments) {
+		await options.client.deleteComment(comment.id);
+	}
+
+	if (options.result.problems.length === 0) {
+		if (!firstManagedComment) return "unchanged";
+		await options.client.deleteComment(firstManagedComment.id);
+		return "deleted";
+	}
+
+	const body = renderWarningComment(options.result);
+	if (!firstManagedComment) {
+		await options.client.createComment(options.issueNumber, body);
+		return "created";
+	}
+
+	if (firstManagedComment.body === body && extraManagedComments.length === 0) {
+		return "unchanged";
+	}
+
+	await options.client.updateComment(firstManagedComment.id, body);
+	return "updated";
+}
+
+async function main(): Promise<void> {
+	const repository = process.env.GITHUB_REPOSITORY;
+	const token = process.env.GITHUB_TOKEN;
+	const issueNumber = Number(process.env.ISSUE_NUMBER);
+
+	if (!repository) throw new Error("GITHUB_REPOSITORY is required");
+	if (!token) throw new Error("GITHUB_TOKEN is required");
+	if (!Number.isInteger(issueNumber) || issueNumber <= 0) throw new Error("ISSUE_NUMBER must be a positive integer");
+
+	const client = new GitHubClient(repository, token);
+	const [issueLabels, repositoryLabels] = await Promise.all([client.fetchIssueLabels(issueNumber), client.fetchRepositoryLabels()]);
+	const result = analyzeIssueLabelHealth({ issueLabels, repositoryLabels });
+	const action = await reconcileManagedComment({ client, issueNumber, result });
+
+	console.log(JSON.stringify({ issueNumber, problems: result.problems.length, action }, null, 2));
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+	await main();
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "skipLibCheck": true,
     "strict": true
   },
-  "include": ["extensions/**/*.ts", "lib/**/*.ts"]
+  "include": ["extensions/**/*.ts", "lib/**/*.ts", "scripts/**/*.ts"]
 }


### PR DESCRIPTION
Adds an issue-label health workflow backed by scripts/pac-label-health.ts, including managed warning comments for conflicting pac labels, legacy labels, and setup drift.

Verification: npm test; npm run typecheck

closes #203
