### PR TITLE
✨ feat(skills): Add pac-tdd workflow skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,8 @@ For deeper guidance on creating or updating prompt templates in `prompts/`, load
 
 For deeper guidance on creating, renaming, or refactoring repo-local skills in `skills/`, load `skills/pac-pi-skill/SKILL.md`.
 
+For behavior-changing implementation work, feature slices, or bug fixes where regression coverage matters, load `skills/pac-tdd/SKILL.md`.
+
 For disciplined bug diagnosis or performance-regression investigation, load `skills/pac-diagnose/SKILL.md`.
 
 For GitHub issue triage, label-state recommendations, ready-for-agent briefs, needs-info comments, wontfix decisions, or out-of-scope scope-boundary comments, load `skills/pac-triage/SKILL.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioned sections should match the Git tags and GitHub releases published for t
 
 ### Added
 
+- Added `pac-tdd` as a standalone pragmatic TDD skill with lightweight notes for tests, mocking, refactoring, deep modules, and interface design. ([#155](https://github.com/ladislas/mypac/issues/155))
 - Added this changelog to track notable repository changes and future GitHub releases. ([#139](https://github.com/ladislas/mypac/issues/139))
 - Added a `/pac-slidedeck` extension command and `save_slidedeck` tool that generate presentation-style HTML decks under `~/.pi/agent/slidedecks/` instead of the repo workspace. ([#131](https://github.com/ladislas/mypac/issues/131))
 - Added `pac-grill-with-docs`, its thin `/pac-grill-with-docs` prompt, and an initial repo-root `CONTEXT.md` to support GitHub-first grilling, issue-backed ADR comments, and sparing local context updates. ([#157](https://github.com/ladislas/mypac/issues/157))

--- a/skills/pac-tdd/SKILL.md
+++ b/skills/pac-tdd/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: pac-tdd
+description: "Guide pragmatic test-driven implementation through small vertical slices. Use when implementing behavior-changing features or bug fixes, especially when tests, regression coverage, red-green-refactor, tracer bullets, or public-interface testing are relevant."
+license: MIT
+compatibility: Pi coding agent
+metadata:
+  author: mypac
+  stage: shared
+---
+
+# Pragmatic TDD
+
+Use this skill for behavior-changing implementation: new features, bug fixes, and changes where regression coverage matters. Do not add ceremony for trivial edits, docs-only changes, wording-only prompt or skill edits, mechanical renames, config-only changes, exploratory spikes, or work already fully covered by existing checks.
+
+## Core rule
+
+Work in small vertical slices:
+
+```text
+RED:   Add one focused test for one observable behavior and watch it fail.
+GREEN: Add the smallest implementation that makes that test pass.
+REFACTOR: Clean up only after tests are green, then run checks again.
+```
+
+Do not write all tests first and all implementation later. That horizontal slice usually tests imagined structure instead of learned behavior.
+
+## Before coding
+
+- State the public behavior you are about to change.
+- Identify the public interface or command that should prove the behavior.
+- Pick the first tracer-bullet test: the smallest end-to-end path that exercises the real seam.
+- State any skipped-test rationale up front if TDD is not appropriate.
+
+For larger or ambiguous work, confirm the plan with the user before implementation.
+
+## Test shape
+
+Default to behavior-level tests through public interfaces. A good test should still pass after an internal refactor when behavior is unchanged.
+
+Use focused internal unit tests only when they are the simplest honest way to cover complex logic or a hard-to-reach legacy seam. If you do, name the reason.
+
+Load deeper notes when relevant:
+
+- [tests.md](tests.md) — choosing behavior-level tests and avoiding implementation-detail assertions
+- [mocking.md](mocking.md) — mocking only at real system boundaries
+- [refactoring.md](refactoring.md) — safe cleanup once tests are green
+- [deep-modules.md](deep-modules.md) — shaping testable modules with small interfaces and deep implementations
+- [interface-design.md](interface-design.md) — designing public seams that are easy to exercise
+
+## Cycle checklist
+
+For each slice:
+
+- [ ] The test describes observable behavior, not implementation mechanics.
+- [ ] The test uses a public interface unless a tactical internal seam is justified.
+- [ ] The test fails for the expected reason before implementation when practical.
+- [ ] The implementation is the smallest useful change for this behavior.
+- [ ] All relevant tests pass before refactoring.
+- [ ] Any refactor stays inside the proven behavior.
+
+## Bug-fix handoff from `pac-diagnose`
+
+Keep diagnosis separate. Use `pac-diagnose` to isolate the bug and find a reliable repro. Then use this skill to turn the repro into a failing regression test, implement the fix, and refactor only after the regression passes.
+
+## Commit and report
+
+Commit meaningful completed green/refactor slices, not every tiny red-green step.
+
+When reporting back, include:
+
+- tests added or updated,
+- checks run,
+- behaviors covered,
+- skipped-test rationale when no tests were added,
+- the next slice if work remains incomplete.

--- a/skills/pac-tdd/deep-modules.md
+++ b/skills/pac-tdd/deep-modules.md
@@ -1,0 +1,17 @@
+# Deep Modules and Testability
+
+A deep module has a small interface with meaningful behavior behind it. Tests become simpler because callers have fewer seams to understand.
+
+```text
+Deep:    simple command or function -> handles parsing, validation, and orchestration inside
+Shallow: many tiny pass-through calls -> callers and tests must coordinate every step
+```
+
+When designing a slice, ask:
+
+- Can one public operation hide more of the workflow?
+- Can parameters be simpler or more domain-shaped?
+- Does the interface expose decisions that should stay internal?
+- Would deleting this module concentrate complexity in one better place, or scatter it across callers?
+
+Use deep modules to make behavior tests natural. Do not introduce abstraction just to make a mock possible.

--- a/skills/pac-tdd/interface-design.md
+++ b/skills/pac-tdd/interface-design.md
@@ -1,0 +1,29 @@
+# Interface Design for Testability
+
+Design public seams so behavior can be exercised without brittle setup.
+
+Prefer interfaces that:
+
+- accept boundary dependencies instead of creating them internally;
+- return explicit results or documented side effects;
+- use domain-shaped inputs and outputs;
+- keep the surface area small;
+- make invalid states hard to represent when practical.
+
+Avoid interfaces that require tests to:
+
+- patch globals or hidden singletons;
+- inspect private state;
+- coordinate many shallow helper calls;
+- know storage details to verify a user-visible result.
+
+## Example shape
+
+```text
+GOOD: planRelease({ repo, changelog, version }) -> release plan
+GOOD: applyReleasePlan(plan, { git, filesystem }) -> result
+
+BAD: helper calls that expose every intermediate parsing and formatting step as public API
+```
+
+The goal is not more interfaces. The goal is one honest seam where tests can prove behavior that matters.

--- a/skills/pac-tdd/mocking.md
+++ b/skills/pac-tdd/mocking.md
@@ -1,0 +1,32 @@
+# Mocking Guidance
+
+Mock real system boundaries, not your own design.
+
+Good mock targets:
+
+- external APIs and SDK clients;
+- email, payment, analytics, and notification services;
+- time, randomness, environment, and network boundaries;
+- file systems or databases when a real test resource is too slow or unsafe.
+
+Avoid mocking:
+
+- internal collaborators you control;
+- private methods;
+- modules created only to make assertions convenient;
+- behavior that a faster public-interface test can exercise honestly.
+
+## Design boundary interfaces deliberately
+
+Pass boundary dependencies in from the outside so tests can supply fakes without reaching into internals.
+
+```text
+GOOD: runSync({ clock, apiClient, workspace })
+BAD:  runSync() constructs real clock, client, and workspace internally
+```
+
+Prefer specific boundary operations over one generic catch-all function. A fake `getUser(id)` or `sendReceipt(orderId)` is easier to read than a fake `request(url, options)` full of conditional branches.
+
+## Mocking smell test
+
+If changing an internal function name breaks the test while user-visible behavior is unchanged, the mock is probably coupled to implementation details.

--- a/skills/pac-tdd/refactoring.md
+++ b/skills/pac-tdd/refactoring.md
@@ -1,0 +1,22 @@
+# Refactoring After Green
+
+Refactor only after the relevant tests pass.
+
+Look for cleanup that improves locality without expanding scope:
+
+- duplicate logic introduced by the current slice;
+- names that now obscure the behavior;
+- long functions that can hide complexity behind a clearer public seam;
+- shallow pass-through modules that can be removed or deepened;
+- tangled setup that makes the next behavior test hard to write.
+
+## Safe loop
+
+```text
+1. Confirm tests are green.
+2. Make one small refactor.
+3. Run the focused tests again.
+4. Continue only while behavior stays proven.
+```
+
+Do not mix new behavior with refactoring. If a cleanup reveals another feature or bug, capture it as the next slice or a follow-up.

--- a/skills/pac-tdd/tests.md
+++ b/skills/pac-tdd/tests.md
@@ -1,0 +1,34 @@
+# Behavior-First Tests
+
+Prefer tests that describe what callers can observe through a public interface.
+
+Good tests:
+
+- exercise the same seam a caller, command, hook, or user workflow uses;
+- describe the behavior in the test name;
+- assert outcomes, returned values, rendered state, emitted files, or documented side effects;
+- survive internal refactors when behavior stays the same;
+- keep each test focused on one behavior.
+
+Avoid tests that mainly verify implementation mechanics:
+
+- private methods or unexported helpers;
+- call counts or call order between internal collaborators;
+- internal data structures that callers cannot observe;
+- snapshots of broad incidental output;
+- database or file-system inspection when a public read path exists.
+
+## Example
+
+```text
+GOOD: "create user makes the user retrievable by id"
+  createUser(input)
+  getUser(result.id) returns the created user's public fields
+
+BAD: "create user calls userRepository.insert once"
+  assert internal collaborator calls instead of observable behavior
+```
+
+## Tactical internal tests
+
+Internal unit tests are allowed when behavior-level coverage is impractical or would be dishonest. Use them for dense pure logic, legacy seams, or failure cases that cannot be reached through the public surface without brittle setup. State the rationale, and keep the public behavior test as the preferred target when the seam improves.


### PR DESCRIPTION
Adds a standalone pragmatic TDD skill with lightweight support notes and repo guidance for when agents should load it.

Verification: node skill contract check; npm test; npm run typecheck

Follow-up: #210

closes #155
