### PR TITLE
✨ feat(upstream): Add upstream checkpoint workflow

### DIFF
--- a/.pac/upstream-sources.yaml
+++ b/.pac/upstream-sources.yaml
@@ -1,0 +1,122 @@
+# Canonical registry for upstream/reference sources that inspired mypac.
+#
+# This file is the machine-readable checkpoint for /pac-upstream-checkpoints.
+# GitHub checkpoint issues are the durable review narrative and decision log.
+# Advance last_reviewed only after human confirmation from a checkpoint issue.
+schema_version: 1
+checkpoint_label: pac:upstream-checkpoint
+sources:
+  - id: agent-stuff-pi-extensions
+    title: Agent Stuff Pi extensions
+    kind: extension-set
+    source:
+      repo: https://github.com/mitsuhiko/agent-stuff
+      ref: main
+      paths:
+        - extensions/answer.ts
+        - extensions/btw.ts
+        - extensions/files.ts
+        - extensions/multi-edit.ts
+        - extensions/review.ts
+        - extensions/todos.ts
+        - extensions/uv.ts
+        - extensions/whimsical.ts
+    local:
+      paths:
+        - extensions/answer/
+        - extensions/btw/
+        - extensions/files/
+        - extensions/multi-edit/
+        - extensions/review/
+        - extensions/todos/
+        - extensions/uv/
+        - extensions/whimsical/
+    attribution:
+      upstream: mitsuhiko/agent-stuff
+      license: Review upstream repository before copying new code.
+      notes: Existing local files include inline original-source comments; README gives broad credit.
+    known_divergence:
+      - Local extensions may be split into helper modules and tests to satisfy mypac extension layout rules.
+    last_reviewed:
+      commit: null
+      checkpoint_issue: null
+      reviewed_at: null
+      notes: Initial registry entry; no checkpoint review has advanced this baseline yet.
+
+  - id: agent-stuff-pi-skills
+    title: Agent Stuff Pi skills
+    kind: skill-set
+    source:
+      repo: https://github.com/mitsuhiko/agent-stuff
+      ref: main
+      paths:
+        - skills/github/SKILL.md
+        - skills/librarian/SKILL.md
+        - skills/librarian/checkout.sh
+        - skills/uv/SKILL.md
+        - skills/uv/build.md
+        - skills/uv/scripts.md
+    local:
+      paths:
+        - skills/pac-github/
+        - skills/pac-librarian/
+        - skills/pac-uv/
+    attribution:
+      upstream: mitsuhiko/agent-stuff
+      license: Review upstream repository before copying new code.
+      notes: Local skill names use the pac- prefix and adapt behavior to this repository.
+    known_divergence:
+      - mypac adds repository-specific conventions and safety checks.
+    last_reviewed:
+      commit: null
+      checkpoint_issue: null
+      reviewed_at: null
+      notes: Initial registry entry; no checkpoint review has advanced this baseline yet.
+
+  - id: mattpocock-skills-authoring
+    title: Matt Pocock skill authoring patterns
+    kind: workflow-pattern
+    source:
+      repo: https://github.com/mattpocock/skills
+      ref: main
+      paths:
+        - skills/productivity/write-a-skill/
+        - to-prd/
+    local:
+      paths:
+        - skills/pac-pi-skill/SKILL.md
+        - skills/pac-grill-with-docs/PRD-FORMAT.md
+    attribution:
+      upstream: mattpocock/skills
+      license: Review upstream repository before copying new text or structure.
+      notes: Local guidance is adapted to Pi and mypac naming conventions.
+    known_divergence:
+      - mypac skills require pac- prefixes and repository-specific frontmatter guidance.
+    last_reviewed:
+      commit: null
+      checkpoint_issue: null
+      reviewed_at: null
+      notes: Initial registry entry; no checkpoint review has advanced this baseline yet.
+
+  - id: pi-mono-release-notes
+    title: Pi Mono release note conventions
+    kind: documentation-pattern
+    source:
+      repo: https://github.com/badlogic/pi-mono
+      ref: main
+      paths:
+        - packages/coding-agent/CHANGELOG.md
+    local:
+      paths:
+        - CHANGELOG.md
+    attribution:
+      upstream: badlogic/pi-mono
+      license: Review upstream repository before copying new text or structure.
+      notes: CHANGELOG.md also credits Keep a Changelog.
+    known_divergence:
+      - mypac keeps an Unreleased section and groups changes for this repository's workflow.
+    last_reviewed:
+      commit: null
+      checkpoint_issue: null
+      reviewed_at: null
+      notes: Initial registry entry; no checkpoint review has advanced this baseline yet.

--- a/.pac/upstream-sources.yaml
+++ b/.pac/upstream-sources.yaml
@@ -1,122 +1,239 @@
-# Canonical registry for upstream/reference sources that inspired mypac.
+# Canonical registry for local mypac artifacts with upstream/reference provenance.
 #
 # This file is the machine-readable checkpoint for /pac-upstream-checkpoints.
 # GitHub checkpoint issues are the durable review narrative and decision log.
 # Advance last_reviewed only after human confirmation from a checkpoint issue.
-schema_version: 1
+schema_version: 3
 checkpoint_label: pac:upstream-checkpoint
-sources:
-  - id: agent-stuff-pi-extensions
-    title: Agent Stuff Pi extensions
+local_artifacts:
+  - id: pi-extensions-agent-stuff-adaptations
+    title: Local Pi extensions adapted from Agent Stuff
     kind: extension-set
-    source:
-      repo: https://github.com/mitsuhiko/agent-stuff
-      ref: main
-      paths:
-        - extensions/answer.ts
-        - extensions/btw.ts
-        - extensions/files.ts
-        - extensions/multi-edit.ts
-        - extensions/review.ts
-        - extensions/todos.ts
-        - extensions/uv.ts
-        - extensions/whimsical.ts
     local:
       paths:
         - extensions/answer/
         - extensions/btw/
         - extensions/files/
         - extensions/multi-edit/
-        - extensions/review/
         - extensions/todos/
         - extensions/uv/
         - extensions/whimsical/
+    upstream_refs:
+      - id: agent-stuff-pi-extensions
+        role: source_adaptation
+        status: active
+        repo: https://github.com/mitsuhiko/agent-stuff
+        ref: main
+        paths:
+          - extensions/answer.ts
+          - extensions/btw.ts
+          - extensions/files.ts
+          - extensions/multi-edit.ts
+          - extensions/todos.ts
+          - extensions/uv.ts
+          - extensions/whimsical.ts
+        attribution:
+          upstream: mitsuhiko/agent-stuff
+          license: Review upstream repository before copying new code.
+          notes: Existing local files include inline original-source comments; README gives broad credit. Review is tracked separately by `pi-review-extension` because it now has multiple upstream references.
+        last_reviewed:
+          commit: null
+          checkpoint_issue: null
+          reviewed_at: null
+          notes: Initial registry entry; no checkpoint review has advanced this baseline yet.
     attribution:
       upstream: mitsuhiko/agent-stuff
       license: Review upstream repository before copying new code.
-      notes: Existing local files include inline original-source comments; README gives broad credit.
+      notes: Local extensions may be split into helper modules and tests to satisfy mypac extension layout rules.
     known_divergence:
       - Local extensions may be split into helper modules and tests to satisfy mypac extension layout rules.
-    last_reviewed:
-      commit: null
-      checkpoint_issue: null
-      reviewed_at: null
-      notes: Initial registry entry; no checkpoint review has advanced this baseline yet.
 
-  - id: agent-stuff-pi-skills
-    title: Agent Stuff Pi skills
-    kind: skill-set
-    source:
-      repo: https://github.com/mitsuhiko/agent-stuff
-      ref: main
+  - id: pi-review-extension
+    title: Pi review extension and review skill
+    kind: extension-and-skill
+    local:
       paths:
-        - skills/github/SKILL.md
-        - skills/librarian/SKILL.md
-        - skills/librarian/checkout.sh
-        - skills/uv/SKILL.md
-        - skills/uv/build.md
-        - skills/uv/scripts.md
+        - extensions/review/
+        - skills/pac-review/
+    upstream_refs:
+      - id: agent-stuff-review-original
+        role: original_provenance
+        status: historical
+        repo: https://github.com/mitsuhiko/agent-stuff
+        ref: main
+        paths:
+          - extensions/review.ts
+        attribution:
+          upstream: mitsuhiko/agent-stuff/extensions/review.ts
+          license: Review upstream repository before copying new code.
+          notes: Original provenance for the review idea and earlier local fork.
+        last_reviewed:
+          commit: null
+          checkpoint_issue: null
+          reviewed_at: null
+          notes: Initial registry entry; no checkpoint review has advanced this baseline yet.
+      - id: pi-review-current-reference
+        role: current_reference
+        status: active
+        repo: https://github.com/earendil-works/pi-review
+        ref: main
+        paths:
+          - review.ts
+        attribution:
+          upstream: earendil-works/pi-review/review.ts
+          license: Review upstream repository before copying new code.
+          notes: "Per #117, this is the newer reference source for concrete prompt, rubric, bugfix, and robustness changes."
+        last_reviewed:
+          commit: null
+          checkpoint_issue: null
+          reviewed_at: null
+          notes: Initial registry entry; no checkpoint review has advanced this baseline yet.
+    attribution:
+      upstream: mitsuhiko/agent-stuff and earendil-works/pi-review
+      license: Review each upstream repository before copying new code or text.
+      notes: Local implementation combines review extension behavior with a pac-prefixed review skill and repo-specific review conventions.
+    known_divergence:
+      - "Per #118 and PR #190, mypac intentionally trimmed inherited review modes/features and should not chase wholesale feature parity with upstream review implementations."
+      - Missing upstream loop-fixing, custom-persistence, broad local-changes review, or other removed complexity is intentional unless a concrete prompt, rubric, bugfix, or robustness change is identified.
+      - Future checkpoints should compare `earendil-works/pi-review` closely for targeted improvements and treat `agent-stuff` as original provenance unless it contains a materially new review idea.
+
+  - id: pi-skills-agent-stuff-adaptations
+    title: Local Pi skills adapted from Agent Stuff
+    kind: skill-set
     local:
       paths:
         - skills/pac-github/
         - skills/pac-librarian/
         - skills/pac-uv/
+    upstream_refs:
+      - id: agent-stuff-pi-skills
+        role: source_adaptation
+        status: active
+        repo: https://github.com/mitsuhiko/agent-stuff
+        ref: main
+        paths:
+          - skills/github/SKILL.md
+          - skills/librarian/SKILL.md
+          - skills/librarian/checkout.sh
+          - skills/uv/SKILL.md
+          - skills/uv/build.md
+          - skills/uv/scripts.md
+        attribution:
+          upstream: mitsuhiko/agent-stuff
+          license: Review upstream repository before copying new code.
+          notes: Local skill names use the pac- prefix and adapt behavior to this repository.
+        last_reviewed:
+          commit: null
+          checkpoint_issue: null
+          reviewed_at: null
+          notes: Initial registry entry; no checkpoint review has advanced this baseline yet.
     attribution:
       upstream: mitsuhiko/agent-stuff
       license: Review upstream repository before copying new code.
       notes: Local skill names use the pac- prefix and adapt behavior to this repository.
     known_divergence:
       - mypac adds repository-specific conventions and safety checks.
-    last_reviewed:
-      commit: null
-      checkpoint_issue: null
-      reviewed_at: null
-      notes: Initial registry entry; no checkpoint review has advanced this baseline yet.
 
-  - id: mattpocock-skills-authoring
-    title: Matt Pocock skill authoring patterns
+  - id: mattpocock-skill-authoring-patterns
+    title: Matt Pocock skill and PRD authoring patterns
     kind: workflow-pattern
-    source:
-      repo: https://github.com/mattpocock/skills
-      ref: main
-      paths:
-        - skills/productivity/write-a-skill/
-        - to-prd/
     local:
       paths:
         - skills/pac-pi-skill/SKILL.md
+        - skills/pac-to-prd/SKILL.md
         - skills/pac-grill-with-docs/PRD-FORMAT.md
+    upstream_refs:
+      - id: mattpocock-skills-authoring
+        role: pattern_source
+        status: active
+        repo: https://github.com/mattpocock/skills
+        ref: main
+        paths:
+          - skills/productivity/write-a-skill/SKILL.md
+          - skills/engineering/to-prd/SKILL.md
+        attribution:
+          upstream: mattpocock/skills
+          license: Review upstream repository before copying new text or structure.
+          notes: Local guidance is adapted to Pi and mypac naming conventions. The historical upstream `to-prd/` path was reorganized; use `skills/engineering/to-prd/SKILL.md` for current PRD-pattern checks.
+        last_reviewed:
+          commit: null
+          checkpoint_issue: null
+          reviewed_at: null
+          notes: Initial registry entry; no checkpoint review has advanced this baseline yet. Path repair only; baseline intentionally not advanced.
     attribution:
       upstream: mattpocock/skills
       license: Review upstream repository before copying new text or structure.
       notes: Local guidance is adapted to Pi and mypac naming conventions.
     known_divergence:
       - mypac skills require pac- prefixes and repository-specific frontmatter guidance.
-    last_reviewed:
-      commit: null
-      checkpoint_issue: null
-      reviewed_at: null
-      notes: Initial registry entry; no checkpoint review has advanced this baseline yet.
+      - "Per #135, many Matt Pocock skill adaptations were already reviewed or intentionally scoped; do not reopen every previously decided adaptation during path repair."
 
-  - id: pi-mono-release-notes
-    title: Pi Mono release note conventions
+  - id: changelog-release-notes
+    title: Changelog release note conventions
     kind: documentation-pattern
-    source:
-      repo: https://github.com/badlogic/pi-mono
-      ref: main
-      paths:
-        - packages/coding-agent/CHANGELOG.md
     local:
       paths:
         - CHANGELOG.md
+    upstream_refs:
+      - id: pi-mono-release-notes
+        role: pattern_source
+        status: active
+        repo: https://github.com/badlogic/pi-mono
+        ref: main
+        paths:
+          - packages/coding-agent/CHANGELOG.md
+        attribution:
+          upstream: badlogic/pi-mono
+          license: Review upstream repository before copying new text or structure.
+          notes: CHANGELOG.md also credits Keep a Changelog.
+        last_reviewed:
+          commit: null
+          checkpoint_issue: null
+          reviewed_at: null
+          notes: Initial registry entry; no checkpoint review has advanced this baseline yet.
     attribution:
       upstream: badlogic/pi-mono
       license: Review upstream repository before copying new text or structure.
       notes: CHANGELOG.md also credits Keep a Changelog.
     known_divergence:
       - mypac keeps an Unreleased section and groups changes for this repository's workflow.
+
+watch_sources:
+  - id: agent-stuff-extensions-watch
+    title: Agent Stuff extension inventory
+    repo: https://github.com/mitsuhiko/agent-stuff
+    ref: main
+    paths:
+      - extensions/
+    purpose: Watch for newly added, moved, or removed upstream extensions that may deserve local artifact entries or explicit non-coverage.
     last_reviewed:
       commit: null
       checkpoint_issue: null
       reviewed_at: null
-      notes: Initial registry entry; no checkpoint review has advanced this baseline yet.
+      notes: Inventory watch only; do not force local adoption.
+
+  - id: agent-stuff-skills-watch
+    title: Agent Stuff skill inventory
+    repo: https://github.com/mitsuhiko/agent-stuff
+    ref: main
+    paths:
+      - skills/
+    purpose: Watch for newly added, moved, or removed upstream skills that may deserve local artifact entries or explicit non-coverage.
+    last_reviewed:
+      commit: null
+      checkpoint_issue: null
+      reviewed_at: null
+      notes: Inventory watch only; do not force local adoption.
+
+  - id: mattpocock-skills-watch
+    title: Matt Pocock skill inventory
+    repo: https://github.com/mattpocock/skills
+    ref: main
+    paths:
+      - skills/
+    purpose: "Watch for newly added, moved, or removed skills after the upstream reorganization; use #135 context before opening any new review thread."
+    last_reviewed:
+      commit: null
+      checkpoint_issue: null
+      reviewed_at: null
+      notes: Inventory watch only; do not reopen every already-decided adaptation.

--- a/.pac/upstream-sources.yaml
+++ b/.pac/upstream-sources.yaml
@@ -1,64 +1,240 @@
 # Canonical registry for local mypac artifacts with upstream/reference provenance.
+# Model contract: skills/pac-upstream-checkpoints/MODEL.md
 #
 # This file is the machine-readable checkpoint for /pac-upstream-checkpoints.
 # GitHub checkpoint issues are the durable review narrative and decision log.
 # Advance last_reviewed only after human confirmation from a checkpoint issue.
-schema_version: 3
+schema_version: 4
 checkpoint_label: pac:upstream-checkpoint
 local_artifacts:
-  - id: pi-extensions-agent-stuff-adaptations
-    title: Local Pi extensions adapted from Agent Stuff
-    kind: extension-set
+  - id: pi-extension-answer
+    title: Answer extension
+    kind: extension
     local:
       paths:
         - extensions/answer/
-        - extensions/btw/
-        - extensions/files/
-        - extensions/multi-edit/
-        - extensions/todos/
-        - extensions/uv/
-        - extensions/whimsical/
     upstream_refs:
-      - id: agent-stuff-pi-extensions
+      - id: agent-stuff-answer-extension
         role: source_adaptation
         status: active
+        sync_policy: targeted
         repo: https://github.com/mitsuhiko/agent-stuff
         ref: main
         paths:
           - extensions/answer.ts
-          - extensions/btw.ts
-          - extensions/files.ts
-          - extensions/multi-edit.ts
-          - extensions/todos.ts
-          - extensions/uv.ts
-          - extensions/whimsical.ts
         attribution:
-          upstream: mitsuhiko/agent-stuff
+          upstream: mitsuhiko/agent-stuff/extensions/answer.ts
           license: Review upstream repository before copying new code.
-          notes: Existing local files include inline original-source comments; README gives broad credit. Review is tracked separately by `pi-review-extension` because it now has multiple upstream references.
+          notes: Local extension may be split into helper modules and tests to satisfy mypac extension layout rules.
         last_reviewed:
-          commit: null
+          upstream_commit: null
           checkpoint_issue: null
           reviewed_at: null
-          notes: Initial registry entry; no checkpoint review has advanced this baseline yet.
+          notes: Initial local-artifact entry; no checkpoint review has advanced this baseline yet.
     attribution:
       upstream: mitsuhiko/agent-stuff
       license: Review upstream repository before copying new code.
-      notes: Local extensions may be split into helper modules and tests to satisfy mypac extension layout rules.
+      notes: Local file includes original-source credit; README gives broad credit.
     known_divergence:
-      - Local extensions may be split into helper modules and tests to satisfy mypac extension layout rules.
+      - Local extension layout may differ from upstream single-file extension layout.
 
-  - id: pi-review-extension
-    title: Pi review extension and review skill
-    kind: extension-and-skill
+  - id: pi-extension-btw
+    title: BTW extension
+    kind: extension
+    local:
+      paths:
+        - extensions/btw/
+    upstream_refs:
+      - id: agent-stuff-btw-extension
+        role: source_adaptation
+        status: active
+        sync_policy: targeted
+        repo: https://github.com/mitsuhiko/agent-stuff
+        ref: main
+        paths:
+          - extensions/btw.ts
+        attribution:
+          upstream: mitsuhiko/agent-stuff/extensions/btw.ts
+          license: Review upstream repository before copying new code.
+          notes: Local extension may be split into helper modules and tests to satisfy mypac extension layout rules.
+        last_reviewed:
+          upstream_commit: null
+          checkpoint_issue: null
+          reviewed_at: null
+          notes: Initial local-artifact entry; no checkpoint review has advanced this baseline yet.
+    attribution:
+      upstream: mitsuhiko/agent-stuff
+      license: Review upstream repository before copying new code.
+      notes: Local file includes original-source credit; README gives broad credit.
+    known_divergence:
+      - Local extension layout may differ from upstream single-file extension layout.
+
+  - id: pi-extension-files
+    title: Files extension
+    kind: extension
+    local:
+      paths:
+        - extensions/files/
+    upstream_refs:
+      - id: agent-stuff-files-extension
+        role: source_adaptation
+        status: active
+        sync_policy: targeted
+        repo: https://github.com/mitsuhiko/agent-stuff
+        ref: main
+        paths:
+          - extensions/files.ts
+        attribution:
+          upstream: mitsuhiko/agent-stuff/extensions/files.ts
+          license: Review upstream repository before copying new code.
+          notes: Local extension may be split into helper modules and tests to satisfy mypac extension layout rules.
+        last_reviewed:
+          upstream_commit: null
+          checkpoint_issue: null
+          reviewed_at: null
+          notes: Initial local-artifact entry; no checkpoint review has advanced this baseline yet.
+    attribution:
+      upstream: mitsuhiko/agent-stuff
+      license: Review upstream repository before copying new code.
+      notes: Local file includes original-source credit; README gives broad credit.
+    known_divergence:
+      - Local extension layout may differ from upstream single-file extension layout.
+
+  - id: pi-extension-multi-edit
+    title: Multi-edit extension
+    kind: extension
+    local:
+      paths:
+        - extensions/multi-edit/
+    upstream_refs:
+      - id: agent-stuff-multi-edit-extension
+        role: source_adaptation
+        status: active
+        sync_policy: targeted
+        repo: https://github.com/mitsuhiko/agent-stuff
+        ref: main
+        paths:
+          - extensions/multi-edit.ts
+        attribution:
+          upstream: mitsuhiko/agent-stuff/extensions/multi-edit.ts
+          license: Review upstream repository before copying new code.
+          notes: Local extension may be split into helper modules and tests to satisfy mypac extension layout rules.
+        last_reviewed:
+          upstream_commit: null
+          checkpoint_issue: null
+          reviewed_at: null
+          notes: Initial local-artifact entry; no checkpoint review has advanced this baseline yet.
+    attribution:
+      upstream: mitsuhiko/agent-stuff
+      license: Review upstream repository before copying new code.
+      notes: Local file includes original-source credit; README gives broad credit.
+    known_divergence:
+      - Local extension layout may differ from upstream single-file extension layout.
+
+  - id: pi-extension-todos
+    title: Todos extension
+    kind: extension
+    local:
+      paths:
+        - extensions/todos/
+    upstream_refs:
+      - id: agent-stuff-todos-extension
+        role: source_adaptation
+        status: active
+        sync_policy: targeted
+        repo: https://github.com/mitsuhiko/agent-stuff
+        ref: main
+        paths:
+          - extensions/todos.ts
+        attribution:
+          upstream: mitsuhiko/agent-stuff/extensions/todos.ts
+          license: Review upstream repository before copying new code.
+          notes: Local extension may be split into helper modules and tests to satisfy mypac extension layout rules.
+        last_reviewed:
+          upstream_commit: null
+          checkpoint_issue: null
+          reviewed_at: null
+          notes: Initial local-artifact entry; no checkpoint review has advanced this baseline yet.
+    attribution:
+      upstream: mitsuhiko/agent-stuff
+      license: Review upstream repository before copying new code.
+      notes: Local file includes original-source credit; README gives broad credit.
+    known_divergence:
+      - Local extension layout may differ from upstream single-file extension layout.
+
+  - id: pi-extension-uv
+    title: UV extension
+    kind: extension
+    local:
+      paths:
+        - extensions/uv/
+    upstream_refs:
+      - id: agent-stuff-uv-extension
+        role: source_adaptation
+        status: active
+        sync_policy: targeted
+        repo: https://github.com/mitsuhiko/agent-stuff
+        ref: main
+        paths:
+          - extensions/uv.ts
+        attribution:
+          upstream: mitsuhiko/agent-stuff/extensions/uv.ts
+          license: Review upstream repository before copying new code.
+          notes: Local extension may be split into helper modules and tests to satisfy mypac extension layout rules.
+        last_reviewed:
+          upstream_commit: null
+          checkpoint_issue: null
+          reviewed_at: null
+          notes: Initial local-artifact entry; no checkpoint review has advanced this baseline yet.
+    attribution:
+      upstream: mitsuhiko/agent-stuff
+      license: Review upstream repository before copying new code.
+      notes: Local file includes original-source credit; README gives broad credit.
+    known_divergence:
+      - Local extension layout may differ from upstream single-file extension layout.
+
+  - id: pi-extension-whimsical
+    title: Whimsical extension
+    kind: extension
+    local:
+      paths:
+        - extensions/whimsical/
+    upstream_refs:
+      - id: agent-stuff-whimsical-extension
+        role: source_adaptation
+        status: active
+        sync_policy: targeted
+        repo: https://github.com/mitsuhiko/agent-stuff
+        ref: main
+        paths:
+          - extensions/whimsical.ts
+        attribution:
+          upstream: mitsuhiko/agent-stuff/extensions/whimsical.ts
+          license: Review upstream repository before copying new code.
+          notes: Local extension may be split into helper modules and tests to satisfy mypac extension layout rules.
+        last_reviewed:
+          upstream_commit: null
+          checkpoint_issue: null
+          reviewed_at: null
+          notes: Initial local-artifact entry; no checkpoint review has advanced this baseline yet.
+    attribution:
+      upstream: mitsuhiko/agent-stuff
+      license: Review upstream repository before copying new code.
+      notes: Local file includes original-source credit; README gives broad credit.
+    known_divergence:
+      - Local extension layout may differ from upstream single-file extension layout.
+
+  - id: pi-extension-review
+    title: Review extension
+    kind: extension
     local:
       paths:
         - extensions/review/
-        - skills/pac-review/
     upstream_refs:
-      - id: agent-stuff-review-original
+      - id: agent-stuff-review-original-extension
         role: original_provenance
         status: historical
+        sync_policy: provenance_only
         repo: https://github.com/mitsuhiko/agent-stuff
         ref: main
         paths:
@@ -66,15 +242,16 @@ local_artifacts:
         attribution:
           upstream: mitsuhiko/agent-stuff/extensions/review.ts
           license: Review upstream repository before copying new code.
-          notes: Original provenance for the review idea and earlier local fork.
+          notes: Original provenance for the review extension idea and earlier local fork.
         last_reviewed:
-          commit: null
+          upstream_commit: null
           checkpoint_issue: null
           reviewed_at: null
-          notes: Initial registry entry; no checkpoint review has advanced this baseline yet.
-      - id: pi-review-current-reference
+          notes: Initial local-artifact entry; no checkpoint review has advanced this baseline yet.
+      - id: pi-review-current-reference-extension
         role: current_reference
         status: active
+        sync_policy: targeted
         repo: https://github.com/earendil-works/pi-review
         ref: main
         paths:
@@ -84,156 +261,305 @@ local_artifacts:
           license: Review upstream repository before copying new code.
           notes: "Per #117, this is the newer reference source for concrete prompt, rubric, bugfix, and robustness changes."
         last_reviewed:
-          commit: null
+          upstream_commit: null
           checkpoint_issue: null
           reviewed_at: null
-          notes: Initial registry entry; no checkpoint review has advanced this baseline yet.
+          notes: Initial local-artifact entry; no checkpoint review has advanced this baseline yet.
     attribution:
       upstream: mitsuhiko/agent-stuff and earendil-works/pi-review
       license: Review each upstream repository before copying new code or text.
-      notes: Local implementation combines review extension behavior with a pac-prefixed review skill and repo-specific review conventions.
+      notes: Local implementation adapts review extension behavior to mypac conventions.
     known_divergence:
-      - "Per #118 and PR #190, mypac intentionally trimmed inherited review modes/features and should not chase wholesale feature parity with upstream review implementations."
+      - Local extension layout and supported review modes differ from upstream.
+    do_not_chase:
+      - "Per #118 and PR #190, do not chase wholesale feature parity with upstream review implementations."
       - Missing upstream loop-fixing, custom-persistence, broad local-changes review, or other removed complexity is intentional unless a concrete prompt, rubric, bugfix, or robustness change is identified.
-      - Future checkpoints should compare `earendil-works/pi-review` closely for targeted improvements and treat `agent-stuff` as original provenance unless it contains a materially new review idea.
 
-  - id: pi-skills-agent-stuff-adaptations
-    title: Local Pi skills adapted from Agent Stuff
-    kind: skill-set
+  - id: pi-skill-review
+    title: Review skill
+    kind: skill
+    local:
+      paths:
+        - skills/pac-review/
+    upstream_refs:
+      - id: agent-stuff-review-workflow-source
+        role: original_provenance
+        status: historical
+        sync_policy: provenance_only
+        repo: https://github.com/mitsuhiko/agent-stuff
+        ref: main
+        paths:
+          - extensions/review.ts
+        attribution:
+          upstream: mitsuhiko/agent-stuff/extensions/review.ts
+          license: Review upstream repository before copying new text or structure.
+          notes: Original provenance for review workflow language.
+        last_reviewed:
+          upstream_commit: null
+          checkpoint_issue: null
+          reviewed_at: null
+          notes: Initial local-artifact entry; no checkpoint review has advanced this baseline yet.
+      - id: pi-review-workflow-reference
+        role: current_reference
+        status: active
+        sync_policy: targeted
+        repo: https://github.com/earendil-works/pi-review
+        ref: main
+        paths:
+          - review.ts
+        attribution:
+          upstream: earendil-works/pi-review/review.ts
+          license: Review upstream repository before copying new text or structure.
+          notes: "Per #117, this is the newer reference source for concrete prompt, rubric, bugfix, and robustness changes."
+        last_reviewed:
+          upstream_commit: null
+          checkpoint_issue: null
+          reviewed_at: null
+          notes: Initial local-artifact entry; no checkpoint review has advanced this baseline yet.
+    attribution:
+      upstream: mitsuhiko/agent-stuff and earendil-works/pi-review
+      license: Review each upstream repository before copying code or text.
+      notes: Local skill combines upstream review concepts with repo-specific review conventions.
+    known_divergence:
+      - Local review guidance is intentionally pac-prefixed and repository-specific.
+    do_not_chase:
+      - "Per #118 and PR #190, do not chase wholesale feature parity with upstream review implementations."
+      - Missing upstream loop-fixing, custom-persistence, broad local-changes review, or other removed complexity is intentional unless a concrete prompt, rubric, bugfix, or robustness change is identified.
+
+  - id: pi-skill-github
+    title: GitHub skill
+    kind: skill
     local:
       paths:
         - skills/pac-github/
-        - skills/pac-librarian/
-        - skills/pac-uv/
     upstream_refs:
-      - id: agent-stuff-pi-skills
+      - id: agent-stuff-github-skill
         role: source_adaptation
         status: active
+        sync_policy: targeted
         repo: https://github.com/mitsuhiko/agent-stuff
         ref: main
         paths:
           - skills/github/SKILL.md
+        attribution:
+          upstream: mitsuhiko/agent-stuff/skills/github/SKILL.md
+          license: Review upstream repository before copying new text or structure.
+          notes: Local skill name uses the pac- prefix and adapts behavior to this repository.
+        last_reviewed:
+          upstream_commit: null
+          checkpoint_issue: null
+          reviewed_at: null
+          notes: Initial local-artifact entry; no checkpoint review has advanced this baseline yet.
+    attribution:
+      upstream: mitsuhiko/agent-stuff
+      license: Review upstream repository before copying new text or structure.
+      notes: Local skill name uses the pac- prefix and adapts behavior to this repository.
+    known_divergence:
+      - mypac adds repository-specific conventions and safety checks.
+
+  - id: pi-skill-librarian
+    title: Librarian skill
+    kind: skill
+    local:
+      paths:
+        - skills/pac-librarian/
+    upstream_refs:
+      - id: agent-stuff-librarian-skill
+        role: source_adaptation
+        status: active
+        sync_policy: targeted
+        repo: https://github.com/mitsuhiko/agent-stuff
+        ref: main
+        paths:
           - skills/librarian/SKILL.md
           - skills/librarian/checkout.sh
+        attribution:
+          upstream: mitsuhiko/agent-stuff/skills/librarian
+          license: Review upstream repository before copying new code, text, or structure.
+          notes: Local skill name uses the pac- prefix and adapts behavior to this repository.
+        last_reviewed:
+          upstream_commit: null
+          checkpoint_issue: null
+          reviewed_at: null
+          notes: Initial local-artifact entry; no checkpoint review has advanced this baseline yet.
+    attribution:
+      upstream: mitsuhiko/agent-stuff
+      license: Review upstream repository before copying new code, text, or structure.
+      notes: Local skill name uses the pac- prefix and adapts behavior to this repository.
+    known_divergence:
+      - mypac adds repository-specific conventions and safety checks.
+
+  - id: pi-skill-uv
+    title: UV skill
+    kind: skill
+    local:
+      paths:
+        - skills/pac-uv/
+    upstream_refs:
+      - id: agent-stuff-uv-skill
+        role: source_adaptation
+        status: active
+        sync_policy: targeted
+        repo: https://github.com/mitsuhiko/agent-stuff
+        ref: main
+        paths:
           - skills/uv/SKILL.md
           - skills/uv/build.md
           - skills/uv/scripts.md
         attribution:
-          upstream: mitsuhiko/agent-stuff
-          license: Review upstream repository before copying new code.
-          notes: Local skill names use the pac- prefix and adapt behavior to this repository.
+          upstream: mitsuhiko/agent-stuff/skills/uv
+          license: Review upstream repository before copying new text or structure.
+          notes: Local skill name uses the pac- prefix and adapts behavior to this repository.
         last_reviewed:
-          commit: null
+          upstream_commit: null
           checkpoint_issue: null
           reviewed_at: null
-          notes: Initial registry entry; no checkpoint review has advanced this baseline yet.
+          notes: Initial local-artifact entry; no checkpoint review has advanced this baseline yet.
     attribution:
       upstream: mitsuhiko/agent-stuff
-      license: Review upstream repository before copying new code.
-      notes: Local skill names use the pac- prefix and adapt behavior to this repository.
+      license: Review upstream repository before copying new text or structure.
+      notes: Local skill name uses the pac- prefix and adapts behavior to this repository.
     known_divergence:
       - mypac adds repository-specific conventions and safety checks.
 
-  - id: mattpocock-skill-authoring-patterns
-    title: Matt Pocock skill and PRD authoring patterns
-    kind: workflow-pattern
+  - id: pi-skill-authoring
+    title: Pi skill authoring skill
+    kind: skill
     local:
       paths:
-        - skills/pac-pi-skill/SKILL.md
-        - skills/pac-to-prd/SKILL.md
-        - skills/pac-grill-with-docs/PRD-FORMAT.md
+        - skills/pac-pi-skill/
     upstream_refs:
-      - id: mattpocock-skills-authoring
+      - id: mattpocock-write-a-skill
         role: pattern_source
         status: active
+        sync_policy: targeted
         repo: https://github.com/mattpocock/skills
         ref: main
         paths:
           - skills/productivity/write-a-skill/SKILL.md
-          - skills/engineering/to-prd/SKILL.md
         attribution:
-          upstream: mattpocock/skills
+          upstream: mattpocock/skills/skills/productivity/write-a-skill/SKILL.md
           license: Review upstream repository before copying new text or structure.
-          notes: Local guidance is adapted to Pi and mypac naming conventions. The historical upstream `to-prd/` path was reorganized; use `skills/engineering/to-prd/SKILL.md` for current PRD-pattern checks.
+          notes: Local guidance is adapted to Pi and mypac naming conventions.
         last_reviewed:
-          commit: null
+          upstream_commit: null
           checkpoint_issue: null
           reviewed_at: null
-          notes: Initial registry entry; no checkpoint review has advanced this baseline yet. Path repair only; baseline intentionally not advanced.
+          notes: Initial local-artifact entry; no checkpoint review has advanced this baseline yet. Path repair only; baseline intentionally not advanced.
     attribution:
       upstream: mattpocock/skills
       license: Review upstream repository before copying new text or structure.
       notes: Local guidance is adapted to Pi and mypac naming conventions.
     known_divergence:
       - mypac skills require pac- prefixes and repository-specific frontmatter guidance.
-      - "Per #135, many Matt Pocock skill adaptations were already reviewed or intentionally scoped; do not reopen every previously decided adaptation during path repair."
+    do_not_chase:
+      - "Per #135, do not reopen every previously decided Matt Pocock skill adaptation during path repair."
 
-  - id: changelog-release-notes
-    title: Changelog release note conventions
-    kind: documentation-pattern
+  - id: pi-skill-to-prd
+    title: PRD synthesis skill
+    kind: skill
     local:
       paths:
-        - CHANGELOG.md
+        - skills/pac-to-prd/
     upstream_refs:
-      - id: pi-mono-release-notes
+      - id: mattpocock-to-prd
         role: pattern_source
         status: active
-        repo: https://github.com/badlogic/pi-mono
+        sync_policy: targeted
+        repo: https://github.com/mattpocock/skills
         ref: main
         paths:
-          - packages/coding-agent/CHANGELOG.md
+          - skills/engineering/to-prd/SKILL.md
         attribution:
-          upstream: badlogic/pi-mono
+          upstream: mattpocock/skills/skills/engineering/to-prd/SKILL.md
           license: Review upstream repository before copying new text or structure.
-          notes: CHANGELOG.md also credits Keep a Changelog.
+          notes: Historical upstream path was reorganized; use this current path for PRD-pattern checks.
         last_reviewed:
-          commit: null
+          upstream_commit: null
           checkpoint_issue: null
           reviewed_at: null
-          notes: Initial registry entry; no checkpoint review has advanced this baseline yet.
+          notes: Initial local-artifact entry; no checkpoint review has advanced this baseline yet. Path repair only; baseline intentionally not advanced.
     attribution:
-      upstream: badlogic/pi-mono
+      upstream: mattpocock/skills
       license: Review upstream repository before copying new text or structure.
-      notes: CHANGELOG.md also credits Keep a Changelog.
+      notes: Local guidance is adapted to Pi and mypac naming conventions.
     known_divergence:
-      - mypac keeps an Unreleased section and groups changes for this repository's workflow.
+      - mypac PRD guidance uses GitHub issue comments and pac workflow conventions.
+    do_not_chase:
+      - "Per #135, do not reopen every previously decided Matt Pocock skill adaptation during path repair."
+
+  - id: pi-skill-grill-with-docs
+    title: Grill-with-docs skill
+    kind: skill
+    local:
+      paths:
+        - skills/pac-grill-with-docs/
+    upstream_refs:
+      - id: mattpocock-to-prd-format
+        role: pattern_source
+        status: active
+        sync_policy: targeted
+        repo: https://github.com/mattpocock/skills
+        ref: main
+        paths:
+          - skills/engineering/to-prd/SKILL.md
+        attribution:
+          upstream: mattpocock/skills/skills/engineering/to-prd/SKILL.md
+          license: Review upstream repository before copying new text or structure.
+          notes: Local PRD comment format draws on upstream PRD authoring patterns.
+        last_reviewed:
+          upstream_commit: null
+          checkpoint_issue: null
+          reviewed_at: null
+          notes: Initial local-artifact entry; no checkpoint review has advanced this baseline yet. Path repair only; baseline intentionally not advanced.
+    attribution:
+      upstream: mattpocock/skills
+      license: Review upstream repository before copying new text or structure.
+      notes: Local skill includes PRD format conventions adapted to GitHub issue comments.
+    known_divergence:
+      - mypac PRD artifacts use hidden markers and GitHub-native context links.
+    do_not_chase:
+      - "Per #135, do not reopen every previously decided Matt Pocock skill adaptation during path repair."
 
 watch_sources:
   - id: agent-stuff-extensions-watch
     title: Agent Stuff extension inventory
+    sync_policy: inventory_watch
     repo: https://github.com/mitsuhiko/agent-stuff
     ref: main
     paths:
       - extensions/
     purpose: Watch for newly added, moved, or removed upstream extensions that may deserve local artifact entries or explicit non-coverage.
     last_reviewed:
-      commit: null
+      upstream_commit: null
       checkpoint_issue: null
       reviewed_at: null
       notes: Inventory watch only; do not force local adoption.
 
   - id: agent-stuff-skills-watch
     title: Agent Stuff skill inventory
+    sync_policy: inventory_watch
     repo: https://github.com/mitsuhiko/agent-stuff
     ref: main
     paths:
       - skills/
     purpose: Watch for newly added, moved, or removed upstream skills that may deserve local artifact entries or explicit non-coverage.
     last_reviewed:
-      commit: null
+      upstream_commit: null
       checkpoint_issue: null
       reviewed_at: null
       notes: Inventory watch only; do not force local adoption.
 
   - id: mattpocock-skills-watch
     title: Matt Pocock skill inventory
+    sync_policy: inventory_watch
     repo: https://github.com/mattpocock/skills
     ref: main
     paths:
       - skills/
     purpose: "Watch for newly added, moved, or removed skills after the upstream reorganization; use #135 context before opening any new review thread."
     last_reviewed:
-      commit: null
+      upstream_commit: null
       checkpoint_issue: null
       reviewed_at: null
       notes: Inventory watch only; do not reopen every already-decided adaptation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioned sections should match the Git tags and GitHub releases published for t
 
 ### Added
 
-- Added `.pac/upstream-sources.yaml`, `pac-upstream-checkpoints`, and `/pac-upstream-checkpoints` for reviewing borrowed upstream sources and creating checkpoint issues. ([#192](https://github.com/ladislas/mypac/issues/192))
+- Added `.pac/upstream-sources.yaml`, `pac-upstream-checkpoints`, and `/pac-upstream-checkpoints` for reviewing borrowed upstream sources, tracking local artifacts, and creating checkpoint issues. ([#192](https://github.com/ladislas/mypac/issues/192))
 - Added `pac-tdd` as a standalone pragmatic TDD skill with lightweight notes for tests, mocking, refactoring, deep modules, and interface design. ([#155](https://github.com/ladislas/mypac/issues/155))
 - Added this changelog to track notable repository changes and future GitHub releases. ([#139](https://github.com/ladislas/mypac/issues/139))
 - Added a `/pac-slidedeck` extension command and `save_slidedeck` tool that generate presentation-style HTML decks under `~/.pi/agent/slidedecks/` instead of the repo workspace. ([#131](https://github.com/ladislas/mypac/issues/131))
@@ -30,7 +30,6 @@ Versioned sections should match the Git tags and GitHub releases published for t
 
 ### Changed
 
-- Updated upstream checkpoint registry/workflow guidance around local-first, multi-source artifacts, including whole-upstream watch sources, a dedicated review-extension source model, and repaired Matt Pocock paths. ([#220](https://github.com/ladislas/mypac/issues/220))
 - Taught implementation-oriented prompts to load `pac-tdd` selectively for behavior-changing work, bug fixes, and regression coverage. ([#210](https://github.com/ladislas/mypac/issues/210))
 - Taught `/ghi` issue creation to infer existing pac workflow state labels and warn users to run `/pac-setup-workflows` when expected labels are missing. ([#202](https://github.com/ladislas/mypac/issues/202))
 - Aligned label-dependent workflows on canonical `pac:*` labels and `/pac-setup-workflows` warnings instead of legacy label fallbacks. ([#199](https://github.com/ladislas/mypac/issues/199))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Versioned sections should match the Git tags and GitHub releases published for t
 
 ### Changed
 
+- Updated upstream checkpoint registry/workflow guidance around local-first, multi-source artifacts, including whole-upstream watch sources, a dedicated review-extension source model, and repaired Matt Pocock paths. ([#220](https://github.com/ladislas/mypac/issues/220))
 - Taught implementation-oriented prompts to load `pac-tdd` selectively for behavior-changing work, bug fixes, and regression coverage. ([#210](https://github.com/ladislas/mypac/issues/210))
 - Taught `/ghi` issue creation to infer existing pac workflow state labels and warn users to run `/pac-setup-workflows` when expected labels are missing. ([#202](https://github.com/ladislas/mypac/issues/202))
 - Aligned label-dependent workflows on canonical `pac:*` labels and `/pac-setup-workflows` warnings instead of legacy label fallbacks. ([#199](https://github.com/ladislas/mypac/issues/199))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioned sections should match the Git tags and GitHub releases published for t
 
 ### Added
 
+- Added `.pac/upstream-sources.yaml`, `pac-upstream-checkpoints`, and `/pac-upstream-checkpoints` for reviewing borrowed upstream sources and creating checkpoint issues. ([#192](https://github.com/ladislas/mypac/issues/192))
 - Added `pac-tdd` as a standalone pragmatic TDD skill with lightweight notes for tests, mocking, refactoring, deep modules, and interface design. ([#155](https://github.com/ladislas/mypac/issues/155))
 - Added this changelog to track notable repository changes and future GitHub releases. ([#139](https://github.com/ladislas/mypac/issues/139))
 - Added a `/pac-slidedeck` extension command and `save_slidedeck` tool that generate presentation-style HTML decks under `~/.pi/agent/slidedecks/` instead of the repo workspace. ([#131](https://github.com/ladislas/mypac/issues/131))

--- a/extensions/pac-setup-workflows/config.ts
+++ b/extensions/pac-setup-workflows/config.ts
@@ -42,6 +42,11 @@ export const REQUIRED_PAC_LABELS: LabelSpec[] = [
 		description: "pac artifact: issue contains an ADR decision comment",
 	},
 	{
+		name: "pac:upstream-checkpoint",
+		color: "C2E0C6",
+		description: "pac artifact: upstream inspiration review checkpoint",
+	},
+	{
 		name: "pac:hitl",
 		color: "D876E3",
 		description: "pac execution: requires human-in-the-loop decisions or approval",

--- a/extensions/pac-setup-workflows/drift.test.mjs
+++ b/extensions/pac-setup-workflows/drift.test.mjs
@@ -10,6 +10,13 @@ test("normalizeColor strips leading hash and uppercases", () => {
 	assert.equal(normalizeColor("#bfDadc"), "BFDADC");
 });
 
+test("required pac labels include upstream checkpoint artifacts", () => {
+	const checkpoint = required("pac:upstream-checkpoint");
+	assert.ok(checkpoint);
+	assert.equal(checkpoint.color, "C2E0C6");
+	assert.equal(checkpoint.description, "pac artifact: upstream inspiration review checkpoint");
+});
+
 test("analyzeLabels reports all required pac labels as missing when none exist", () => {
 	const result = analyzeLabels([label("bug"), label("enhancement")]);
 	assert.equal(result.missing.length, REQUIRED_PAC_LABELS.length);

--- a/prompts/pac-upstream-checkpoints.md
+++ b/prompts/pac-upstream-checkpoints.md
@@ -1,6 +1,6 @@
 ---
 description: "Review local artifacts against upstream inspiration sources and create a GitHub checkpoint issue"
-argument-hint: "[local artifact ID | upstream-ref ID | watch-source ID | all | initialize registry | notes]"
+argument-hint: "[local artifact ID | upstream-ref ID | watch-source ID | all | notes]"
 ---
 
 Review local artifacts and watched upstream inventories recorded for this repository, then create a durable checkpoint issue.
@@ -11,17 +11,16 @@ The optional argument after `/pac-upstream-checkpoints` may be:
 
 - a local artifact ID, upstream-ref ID, or watch-source ID from `.pac/upstream-sources.yaml`
 - `all` or empty, meaning review every registered local artifact and watch source
-- `initialize registry`, meaning create or repair `.pac/upstream-sources.yaml` before review
 - free-form notes that narrow what to inspect
 
 ## Behavior
 
 1. Load and follow `skills/pac-upstream-checkpoints/SKILL.md`.
 2. Check branch safety before editing files. Do not update `.pac/upstream-sources.yaml` on `main`.
-3. Read `.pac/upstream-sources.yaml` and validate the requested scope, including `local_artifacts[].upstream_refs[]` and `watch_sources[]`.
+3. Read `.pac/upstream-sources.yaml` and validate the requested scope against the local-artifact model in `skills/pac-upstream-checkpoints/MODEL.md`, including `local_artifacts[].upstream_refs[]`, `sync_policy`, pointer-only `last_reviewed`, and `watch_sources[]`.
 4. Fetch or refresh upstream sources, preferring `pac-librarian` for GitHub repositories.
-5. Compare upstream commit history against local mappings, using upstream-ref roles/status to avoid re-flagging known divergence; scan watch sources for newly added, moved, removed, or uncovered upstream assets.
-6. Create one GitHub checkpoint issue with `<!-- pac:upstream-checkpoint -->` when relevant changes, partial failures, or blocked sources are found. For first-checkout runs, list findings as independently reviewable items. For no-change runs, report the result in conversation without creating an issue unless `--include-empty` is passed.
+5. Compare upstream commit history against local mappings, using upstream-ref roles, statuses, sync policies, `known_divergence`, and `do_not_chase` to avoid re-flagging settled differences; scan watch sources for newly added, moved, removed, or uncovered upstream assets. Watch-source inventory findings must list every uncovered upstream artifact path for the requested scope, grouped if useful, not only notable examples.
+6. Create one GitHub checkpoint issue with `<!-- pac:upstream-checkpoint -->` when relevant changes, partial failures, or blocked sources are found. For first-checkout runs, list findings as independently reviewable items. For no-change runs, report the result in conversation without creating an issue unless explicitly requested.
 7. Ask before creating follow-up implementation issues or advancing registry `last_reviewed` checkpoints.
 8. Summarize the issue URL, local artifacts and watch sources reviewed, findings, and any blocked sources.
 

--- a/prompts/pac-upstream-checkpoints.md
+++ b/prompts/pac-upstream-checkpoints.md
@@ -1,16 +1,16 @@
 ---
-description: "Review registered upstream inspiration sources and create a GitHub checkpoint issue"
-argument-hint: "[source ID | all | initialize registry | notes]"
+description: "Review local artifacts against upstream inspiration sources and create a GitHub checkpoint issue"
+argument-hint: "[local artifact ID | upstream-ref ID | watch-source ID | all | initialize registry | notes]"
 ---
 
-Review upstream/reference sources recorded for this repository and create a durable checkpoint issue.
+Review local artifacts and watched upstream inventories recorded for this repository, then create a durable checkpoint issue.
 
 Use `skills/pac-upstream-checkpoints/SKILL.md` for the workflow.
 
 The optional argument after `/pac-upstream-checkpoints` may be:
 
-- a source ID from `.pac/upstream-sources.yaml`
-- `all` or empty, meaning review every registered source
+- a local artifact ID, upstream-ref ID, or watch-source ID from `.pac/upstream-sources.yaml`
+- `all` or empty, meaning review every registered local artifact and watch source
 - `initialize registry`, meaning create or repair `.pac/upstream-sources.yaml` before review
 - free-form notes that narrow what to inspect
 
@@ -18,11 +18,11 @@ The optional argument after `/pac-upstream-checkpoints` may be:
 
 1. Load and follow `skills/pac-upstream-checkpoints/SKILL.md`.
 2. Check branch safety before editing files. Do not update `.pac/upstream-sources.yaml` on `main`.
-3. Read `.pac/upstream-sources.yaml` and validate the requested source scope.
+3. Read `.pac/upstream-sources.yaml` and validate the requested scope, including `local_artifacts[].upstream_refs[]` and `watch_sources[]`.
 4. Fetch or refresh upstream sources, preferring `pac-librarian` for GitHub repositories.
-5. Compare upstream commit history and relevant local mappings.
-6. Create one GitHub checkpoint issue with `<!-- pac:upstream-checkpoint -->` when relevant changes, partial failures, or blocked sources are found. For no-change runs, report the result in conversation without creating an issue unless `--include-empty` is passed.
+5. Compare upstream commit history against local mappings, using upstream-ref roles/status to avoid re-flagging known divergence; scan watch sources for newly added, moved, removed, or uncovered upstream assets.
+6. Create one GitHub checkpoint issue with `<!-- pac:upstream-checkpoint -->` when relevant changes, partial failures, or blocked sources are found. For first-checkout runs, list findings as independently reviewable items. For no-change runs, report the result in conversation without creating an issue unless `--include-empty` is passed.
 7. Ask before creating follow-up implementation issues or advancing registry `last_reviewed` checkpoints.
-8. Summarize the issue URL, sources reviewed, findings, and any blocked sources.
+8. Summarize the issue URL, local artifacts and watch sources reviewed, findings, and any blocked sources.
 
 **Provided arguments**: $@

--- a/prompts/pac-upstream-checkpoints.md
+++ b/prompts/pac-upstream-checkpoints.md
@@ -1,0 +1,28 @@
+---
+description: "Review registered upstream inspiration sources and create a GitHub checkpoint issue"
+argument-hint: "[source ID | all | initialize registry | notes]"
+---
+
+Review upstream/reference sources recorded for this repository and create a durable checkpoint issue.
+
+Use `skills/pac-upstream-checkpoints/SKILL.md` for the workflow.
+
+The optional argument after `/pac-upstream-checkpoints` may be:
+
+- a source ID from `.pac/upstream-sources.yaml`
+- `all` or empty, meaning review every registered source
+- `initialize registry`, meaning create or repair `.pac/upstream-sources.yaml` before review
+- free-form notes that narrow what to inspect
+
+## Behavior
+
+1. Load and follow `skills/pac-upstream-checkpoints/SKILL.md`.
+2. Check branch safety before editing files. Do not update `.pac/upstream-sources.yaml` on `main`.
+3. Read `.pac/upstream-sources.yaml` and validate the requested source scope.
+4. Fetch or refresh upstream sources, preferring `pac-librarian` for GitHub repositories.
+5. Compare upstream commit history and relevant local mappings.
+6. Create one GitHub checkpoint issue with `<!-- pac:upstream-checkpoint -->` when relevant changes, partial failures, or blocked sources are found. For no-change runs, report the result in conversation without creating an issue unless `--include-empty` is passed.
+7. Ask before creating follow-up implementation issues or advancing registry `last_reviewed` checkpoints.
+8. Summarize the issue URL, sources reviewed, findings, and any blocked sources.
+
+**Provided arguments**: $@

--- a/skills/pac-upstream-checkpoints/MODEL.md
+++ b/skills/pac-upstream-checkpoints/MODEL.md
@@ -1,0 +1,53 @@
+# Upstream checkpoint registry model
+
+This model defines the vocabulary for `.pac/upstream-sources.yaml` and `/pac-upstream-checkpoints`.
+
+## Core concepts
+
+- **Local artifact**: one individually maintainable repo artifact, such as a single skill, extension, prompt, document, or standalone script. This is the primary registry unit.
+- **Upstream ref**: one source repository/path/ref that explains a local artifact's provenance or provides a current reference for targeted review. Upstream-ref IDs are globally unique so users can target one directly.
+- **Watch source**: an upstream inventory scan for discovering new, moved, removed, or renamed assets. A watch source is not a local artifact and does not imply adoption.
+- **Checkpoint issue**: the durable GitHub review narrative and decision log for an upstream review run.
+- **Registry checkpoint**: the pointer-only `last_reviewed` data stored in YAML so the next run knows where to resume.
+
+## Allowed local artifact kinds
+
+- `skill`: one local skill directory under `skills/`.
+- `extension`: one local extension directory under `extensions/`.
+- `prompt`: one local prompt file under `prompts/`.
+- `document`: one standalone document with active upstream tracking.
+- `script`: one standalone script with active upstream tracking.
+
+Docs or scripts that are part of a skill or extension are covered by that parent artifact.
+
+## Sync policies
+
+Every upstream ref and watch source must declare `sync_policy`.
+
+- `provenance_only`: Records origin or attribution. Do not regularly compare for parity unless a human asks.
+- `targeted`: Check for specific useful improvements, bug fixes, conventions, or rationale. Do not chase feature parity.
+- `inventory_watch`: Scan an upstream path for newly added, moved, removed, or renamed assets.
+
+## Divergence fields
+
+- `known_divergence`: factual differences between local and upstream that help reviewers interpret comparisons.
+- `do_not_chase`: explicit rules for things future reviews should not repeatedly propose.
+
+Both fields may appear on a local artifact or on a specific upstream ref.
+
+## Checkpoint data
+
+`last_reviewed` is pointer-only. It contains:
+
+- `upstream_commit`: upstream commit hash last accepted as the checkpoint baseline, or `null`.
+- `checkpoint_issue`: GitHub issue URL/number for that accepted checkpoint, or `null`.
+- `reviewed_at`: ISO timestamp for that accepted checkpoint, or `null`.
+- `notes`: short baseline notes.
+
+Do not store decision summaries in `last_reviewed`; decisions live in checkpoint issues or ADR comments.
+
+## Out of model
+
+- Top-level artifact groups.
+- Top-level normalized source definitions.
+- Active tracking for documents that only provided initial inspiration and do not need ongoing comparison.

--- a/skills/pac-upstream-checkpoints/SKILL.md
+++ b/skills/pac-upstream-checkpoints/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: pac-upstream-checkpoints
+description: "Review upstream/reference sources against this repository and create GitHub checkpoint issues. Use when checking .pac/upstream-sources.yaml, tracking inspiration drift, or running /pac-upstream-checkpoints."
+license: MIT
+compatibility: Git repository; gh CLI recommended; network access required for remote sources.
+metadata:
+  author: mypac
+  stage: shared
+---
+
+# Upstream inspiration checkpoints
+
+Use this skill to review external sources recorded in `.pac/upstream-sources.yaml`, compare their changes with `mypac`, and create a durable GitHub checkpoint issue.
+
+## Goal
+
+Produce an auditable review artifact that answers:
+
+- what upstream sources were checked,
+- what commit ranges or refs were reviewed,
+- what relevant changes or non-changes were found,
+- which local files or workflows may be affected,
+- what follow-up decisions are suggested,
+- where the next run should resume.
+
+Do not implement upstream changes from this workflow. Suggest follow-up areas and ask for human confirmation before creating implementation issues or advancing registry baselines.
+
+## Registry contract
+
+The registry lives at `.pac/upstream-sources.yaml`.
+
+Each source entry should include:
+
+- `id`: stable machine-friendly source identifier
+- `title`: human-readable review unit
+- `kind`: component/workflow category
+- `source.repo`: upstream repository URL
+- `source.ref`: branch, tag, or ref to inspect
+- `source.paths`: upstream paths relevant to this review unit
+- `local.paths`: local files or directories that map to the upstream source
+- `attribution`: upstream credit, license notes, and provenance notes
+- `known_divergence`: intentional differences reviewers should not treat as defects
+- `last_reviewed`: current machine-readable checkpoint:
+  - `commit`: upstream commit from the last confirmed checkpoint, or `null` for initial setup
+  - `checkpoint_issue`: last checkpoint issue URL/number, or `null`
+  - `reviewed_at`: timestamp of the last confirmed checkpoint, or `null`
+  - `notes`: brief baseline notes
+
+Treat the registry as the current checkpoint, not the audit log. Treat GitHub checkpoint issues as the full narrative and decision log.
+
+## Workflow
+
+1. Confirm repository context.
+
+   ```bash
+   git rev-parse --show-toplevel
+   git branch --show-current
+   gh repo view --json nameWithOwner --jq .nameWithOwner
+   ```
+
+   If `gh` is unavailable or unauthenticated, continue with local comparison where possible and report that issue creation needs GitHub access.
+
+2. Read `.pac/upstream-sources.yaml`.
+
+   - If the file is missing, stop and ask whether to initialize it.
+   - Validate that each entry has the required fields above.
+   - If a field is unknown or missing, report the exact source ID and continue only if the missing value is not needed for the requested scope.
+
+3. Resolve source scope.
+
+   - If the user named one source ID, review only that source.
+   - Otherwise review every source entry.
+   - For initial entries with `last_reviewed.commit: null`, compare the current upstream head with the local mapped files and mark the range as `initial-baseline` instead of inventing a previous commit.
+
+4. Fetch or refresh upstream repositories.
+
+   Prefer `pac-librarian` for GitHub repositories so future runs reuse cached checkouts. For each source:
+
+   ```bash
+   bash skills/pac-librarian/checkout.sh <owner>/<repo> --path-only
+   git -C <checkout> fetch --unshallow 2>/dev/null || true
+   git -C <checkout> fetch --all --prune
+   git -C <checkout> rev-parse <ref>
+   ```
+
+   `pac-librarian` creates shallow clones by default. Run `fetch --unshallow` first so that commit-range comparisons against older `last_reviewed` commits succeed.
+
+   If a source is not a Git repository or cannot be fetched, record the access failure in the checkpoint findings.
+
+5. Walk upstream commit history before raw file comparison.
+
+   For each source with a previous commit:
+
+   ```bash
+   git -C <checkout> log --oneline --decorate <last_reviewed_commit>..<current_head> -- <source paths...>
+   git -C <checkout> diff --stat <last_reviewed_commit>..<current_head> -- <source paths...>
+   ```
+
+   For initial baselines, inspect current upstream files and recent history enough to understand the relationship without claiming a full historical review.
+
+   Pay special attention to:
+
+   - renamed, moved, removed, or radically rewritten files,
+   - breaking workflow or API changes,
+   - process, prompt-design, or authoring convention improvements,
+   - commits whose rationale is unclear from the diff alone.
+
+6. Discover new upstream assets not yet in the registry.
+
+   For each source, derive the parent directories from `source.paths` (for example `extensions/` and `skills/`) and list all files under those directories at the current upstream head:
+
+   ```bash
+   git -C <checkout> ls-tree -r --name-only <ref> -- <parent dirs...>
+   ```
+
+   Compare this list against the union of `source.paths` across all registry entries for the same repository. Flag any paths that are not covered by an existing entry as potential new upstream assets. Include these in the checkpoint findings with a suggested status of `investigate` so a maintainer can decide whether to add them to the registry.
+
+   Skip this step when the source uses the `documentation-pattern` kind or when the upstream paths are individual files rather than directory-scoped.
+
+7. Pull linked upstream PRs/issues selectively.
+
+   Use commit messages, GitHub autolinks, or `gh` only when the commit indicates a removal, rewrite, breaking change, major design shift, or unclear rationale. Do not exhaustively read every linked discussion.
+
+8. Compare against local mappings.
+
+   Inspect the mapped `local.paths` and summarize:
+
+   - relevant differences,
+   - useful ideas already present locally,
+   - upstream changes that do not apply because of known divergence,
+   - possible follow-up areas.
+
+   Keep suggestions separate from decisions. Suggested statuses may be `adopt`, `ignore`, `defer`, `investigate`, or `intentional divergence`.
+
+9. Ensure the checkpoint label exists.
+
+   The registry-level `checkpoint_label` defaults to `pac:upstream-checkpoint`. Before creating an issue, check for it:
+
+   ```bash
+   gh label list --json name --jq '.[].name'
+   ```
+
+   If it is missing and the user approved setup, create it:
+
+   ```bash
+   gh label create "pac:upstream-checkpoint" --description "pac artifact: upstream inspiration review checkpoint" --color "BFDADC"
+   ```
+
+   If label creation fails, create the issue without the label and report the failure.
+
+10. Create one checkpoint issue per run.
+
+   Create a checkpoint issue when relevant changes, partial failures, or blocked sources are found. Use a title like:
+
+   ```text
+   Upstream inspiration checkpoint — YYYY-MM-DD
+   ```
+
+   Issue body structure:
+
+   ````md
+   <!-- pac:upstream-checkpoint -->
+   ## Summary
+
+   <one paragraph: relevant changes found / no relevant changes / partial failure>
+
+   ## Sources reviewed
+
+   ### <source id> — <title>
+
+   - Upstream: <repo>@<ref>
+   - Range: <last commit or initial-baseline>..<current head>
+   - Local mapping: <paths>
+   - Previous checkpoint: <issue or none>
+   - Result: <changes found | no relevant changes | blocked | partial>
+
+   #### Findings
+
+   - <finding, or "No relevant upstream changes found.">
+
+   #### Suggested decisions
+
+   - [ ] <adopt|ignore|defer|investigate|intentional divergence>: <decision prompt>
+
+   ## Next checkpoint data
+
+   ```yaml
+   sources:
+     - id: <source id>
+       commit: <current upstream head>
+       checkpoint_issue: <this issue URL>
+       reviewed_at: <ISO timestamp>
+   ```
+
+   ## Notes
+
+   - Follow-up implementation issues should be created only after human confirmation.
+   ````
+
+1. Do not advance `.pac/upstream-sources.yaml` automatically.
+
+    After creating the issue, ask whether to update `last_reviewed` entries from the `Next checkpoint data`. Only update the registry after explicit confirmation that the checkpoint decisions are accepted.
+
+## No-change runs
+
+By default, do not create a checkpoint issue when no relevant upstream changes are found. Instead, report the result in the conversation and note that the checkpoint baseline is unchanged.
+
+If the user explicitly requests an issue even for no-change runs (for example with `--include-empty`), create a short checkpoint issue that makes the absence of relevant changes explicit. Do not create follow-up issues.
+
+## Examples
+
+Review every registered source:
+
+```text
+/pac-upstream-checkpoints
+```
+
+Review one source only:
+
+```text
+/pac-upstream-checkpoints agent-stuff-pi-skills
+```
+
+Initialize or repair the registry before running a review:
+
+```text
+/pac-upstream-checkpoints initialize registry
+```

--- a/skills/pac-upstream-checkpoints/SKILL.md
+++ b/skills/pac-upstream-checkpoints/SKILL.md
@@ -12,62 +12,65 @@ metadata:
 
 Use this skill to review external sources recorded in `.pac/upstream-sources.yaml`, compare their changes with `mypac`, and create a durable GitHub checkpoint issue.
 
-## Goal
-
-Produce an auditable review artifact that answers:
-
-- what upstream sources were checked,
-- what commit ranges or refs were reviewed,
-- what relevant changes or non-changes were found,
-- which local files or workflows may be affected,
-- what follow-up decisions are suggested,
-- where the next run should resume.
-
 Do not implement upstream changes from this workflow. Suggest follow-up areas and ask for human confirmation before creating implementation issues or advancing registry baselines.
 
-## Registry contract
+## Model
 
-The registry lives at `.pac/upstream-sources.yaml`.
+The registry model and glossary live in `MODEL.md` in this skill directory.
 
-The registry is local-first. Start from the artifact we maintain, then list the upstream refs that explain its provenance, current reference points, or reusable patterns.
+Core contract:
 
-Top-level fields:
+- The registry is local-first: start from the exact local artifact we maintain.
+- One `local_artifacts` entry represents one individually maintainable skill, extension, prompt, document, or script.
+- Broad artifact groups are not registry entries. Use optional tags/categories only for navigation if needed.
+- `watch_sources` are whole-upstream inventory scans and are not local artifacts.
+- Every upstream ref and watch source declares `sync_policy`.
+- `last_reviewed` is pointer-only: `upstream_commit`, `checkpoint_issue`, `reviewed_at`, and `notes`.
+- Review decisions live in GitHub checkpoint issues, not in `last_reviewed`.
 
-- `schema_version`: registry schema version.
-- `checkpoint_label`: GitHub label for checkpoint issues.
-- `local_artifacts`: local review units to check against upstream refs.
-- `watch_sources`: whole upstream inventories to watch for newly added, moved, or removed assets.
+## Registry validation
+
+Read `.pac/upstream-sources.yaml` before review. Required top-level fields:
+
+- `schema_version`
+- `checkpoint_label`
+- `local_artifacts`
+- `watch_sources`
 
 Each `local_artifacts` entry should include:
 
 - `id`: stable machine-friendly local artifact identifier.
 - `title`: human-readable local review unit.
-- `kind`: component/workflow category.
-- `local.paths`: local files or directories that belong to this review unit.
-- `upstream_refs`: one or more upstream references for this local artifact.
-- `attribution`: upstream credit, license notes, and provenance notes for the local artifact.
-- `known_divergence`: intentional differences reviewers should not treat as defects.
+- `kind`: one of `skill`, `extension`, `prompt`, `document`, or `script`.
+- `local.paths`: local files or directories belonging to this artifact.
+- `upstream_refs`: one or more upstream references.
+- `attribution`: upstream credit, license notes, and provenance notes.
+- Optional `known_divergence` and `do_not_chase`.
 
 Each `upstream_refs` item should include:
 
-- `id`: stable machine-friendly upstream-ref identifier within the local artifact.
-- `role`: why this upstream matters, such as `original_provenance`, `current_reference`, `source_adaptation`, `pattern_source`, `historical`, or `watch_only`.
-- `status`: review posture, such as `active`, `historical`, `watch_only`, or `retired`.
-- `repo`, `ref`, and `paths`: upstream repository, ref, and paths for that upstream ref.
-- `attribution`: credit, license, and provenance notes specific to that upstream ref when useful.
-- `last_reviewed`: checkpoint data for that upstream ref:
-  - `commit`: upstream commit from the last confirmed checkpoint, or `null` for initial setup.
-  - `checkpoint_issue`: last checkpoint issue URL/number, or `null`.
-  - `reviewed_at`: timestamp of the last confirmed checkpoint, or `null`.
-  - `notes`: brief baseline notes.
+- `id`: globally unique upstream-ref identifier.
+- `role`
+- `status`
+- `sync_policy`: `provenance_only`, `targeted`, or `inventory_watch`.
+- `repo`, `ref`, and `paths`
+- `attribution`
+- `last_reviewed.upstream_commit`
+- `last_reviewed.checkpoint_issue`
+- `last_reviewed.reviewed_at`
+- `last_reviewed.notes`
+- Optional `known_divergence` and `do_not_chase`.
 
 Each `watch_sources` entry should include:
 
-- `id`, `title`, `repo`, `ref`, and `paths`: the upstream inventory to scan.
-- `purpose`: why this inventory is watched and what kind of newly discovered assets should be flagged.
-- `last_reviewed`: checkpoint data for the inventory scan.
+- `id`, `title`, `sync_policy`, `repo`, `ref`, and `paths`
+- `purpose`
+- `last_reviewed.upstream_commit`
+- `last_reviewed.checkpoint_issue`
+- `last_reviewed.reviewed_at`
+- `last_reviewed.notes`
 
-Treat the registry as the current checkpoint, not the audit log. Treat GitHub checkpoint issues as the full narrative and decision log. Do not advance any `last_reviewed` field unless a human explicitly accepts the checkpoint baseline.
+If a required field is missing, report the exact artifact/ref/source ID. Continue only if the missing value is not needed for the requested scope.
 
 ## Workflow
 
@@ -81,101 +84,90 @@ Treat the registry as the current checkpoint, not the audit log. Treat GitHub ch
 
    If `gh` is unavailable or unauthenticated, continue with local comparison where possible and report that issue creation needs GitHub access.
 
-2. Read `.pac/upstream-sources.yaml`.
-
-   - If the file is missing, stop and ask whether to initialize it.
-   - Validate each `local_artifacts` entry has the required fields above.
-   - Validate each `upstream_refs` item has `id`, `role`, `status`, `repo`, `ref`, `paths`, and `last_reviewed`.
-   - Validate each `watch_sources` entry has `id`, `title`, `repo`, `ref`, `paths`, `purpose`, and `last_reviewed`.
-   - If a field is unknown or missing, report the exact local artifact ID, upstream-ref ID, or watch-source ID; continue only if the missing value is not needed for the requested scope.
-
-3. Resolve review scope.
+2. Resolve review scope.
 
    - If the user named one local artifact ID, review that local artifact and its upstream refs.
    - If the user named one upstream-ref ID inside a local artifact, review only that upstream ref and its local mapping.
    - If the user named one watch-source ID, run only that inventory watch.
    - Otherwise review every local artifact and every watch source.
-   - For initial upstream refs or watch sources with `last_reviewed.commit: null`, compare the current upstream head with the local mapped files or inventory and mark the range as `initial-baseline` instead of inventing a previous commit.
+   - For `sync_policy: provenance_only`, verify attribution/provenance only unless the user explicitly asks for comparison.
+   - For `sync_policy: targeted`, look for concrete transferable improvements, not feature parity.
+   - For `sync_policy: inventory_watch`, scan for upstream inventory changes.
+   - For initial upstream refs or watch sources with `last_reviewed.upstream_commit: null`, compare the current upstream head with the local mapped files or inventory and mark the range as `initial-baseline`.
 
-4. Fetch or refresh upstream repositories.
+3. Fetch or refresh upstream repositories.
 
-   Prefer `pac-librarian` for GitHub repositories so future runs reuse cached checkouts. For each upstream ref or watch source:
+   Prefer `pac-librarian` for GitHub repositories so future runs reuse cached checkouts:
 
    ```bash
-   bash skills/pac-librarian/checkout.sh <owner>/<repo> --path-only
+   bash skills/pac-librarian/checkout.sh <repo-url-or-owner/repo> --path-only
    git -C <checkout> fetch --unshallow 2>/dev/null || true
    git -C <checkout> fetch --all --prune
-   git -C <checkout> rev-parse <ref>
+   current_head="$(git -C <checkout> rev-parse "origin/<ref>" 2>/dev/null || git -C <checkout> rev-parse "<ref>")"
    ```
 
-   `pac-librarian` creates shallow clones by default. Run `fetch --unshallow` first so that commit-range comparisons against older `last_reviewed` commits succeed.
+   Prefer the fetched remote-tracking ref (`origin/<ref>`) for branch names so a stale local branch does not become the checkpoint head. Use the plain `<ref>` fallback for tags, commit SHAs, or non-branch refs.
 
-   If an upstream ref is not a Git repository or cannot be fetched, record the access failure in the checkpoint findings for that review unit.
+   If an upstream ref cannot be fetched or resolved, record the access failure in checkpoint findings.
 
-5. Walk upstream commit history before raw file comparison.
+4. Walk upstream commit history before raw file comparison.
 
-   For each upstream ref or watch source with a previous commit:
+   For each upstream ref or watch source with a previous commit, compare against the resolved `current_head` from step 3:
 
    ```bash
-   git -C <checkout> log --oneline --decorate <last_reviewed_commit>..<current_head> -- <source paths...>
-   git -C <checkout> diff --stat <last_reviewed_commit>..<current_head> -- <source paths...>
+   git -C <checkout> log --oneline --decorate <last_reviewed_upstream_commit>..<current_head> -- <source paths...>
+   git -C <checkout> diff --stat <last_reviewed_upstream_commit>..<current_head> -- <source paths...>
    ```
 
    For initial baselines, inspect current upstream files and recent history enough to understand the relationship without claiming a full historical review.
 
-   Pay special attention to:
+   Pay special attention to renames, removals, rewrites, breaking workflow/API changes, and process, prompt-design, or authoring convention improvements. Pull linked upstream PRs/issues selectively when commits indicate unclear rationale, removals, rewrites, breaking changes, or major design shifts.
 
-   - renamed, moved, removed, or radically rewritten files,
-   - breaking workflow or API changes,
-   - process, prompt-design, or authoring convention improvements,
-   - commits whose rationale is unclear from the diff alone.
+5. Compare against local mappings.
 
-   For local artifacts with multiple upstream refs, compare each ref according to its `role` and `status`. For example, check `current_reference` refs for concrete improvements, while treating `original_provenance` or `historical` refs as provenance unless they contain a materially new idea.
-
-6. Check whole-upstream watch sources for new assets.
-
-   For each `watch_sources` entry, list all files under its watched paths at the current upstream head:
-
-   ```bash
-   git -C <checkout> ls-tree -r --name-only <ref> -- <watch paths...>
-   ```
-
-   Compare this list against the union of registered `upstream_refs[].paths` for the same repository. Flag newly added, moved, removed, or uncovered paths as inventory findings with suggested status `investigate` or `intentional divergence`. A watch-source finding should ask whether to create or update a local artifact entry, not assume adoption.
-
-   Use watch sources for broad discovery. Keep local artifact reviews focused on the upstream refs already mapped to that artifact.
-
-7. Pull linked upstream PRs/issues selectively.
-
-   Use commit messages, GitHub autolinks, or `gh` only when the commit indicates a removal, rewrite, breaking change, major design shift, or unclear rationale. Do not exhaustively read every linked discussion.
-
-8. Compare against local mappings.
-
-   Inspect the mapped `local.paths` and summarize:
+   Inspect mapped `local.paths` and summarize:
 
    - relevant differences,
    - useful ideas already present locally,
-   - upstream changes that do not apply because of known divergence,
+   - upstream changes that do not apply because of `known_divergence` or `do_not_chase`,
    - possible follow-up areas.
 
    Keep suggestions separate from decisions. Suggested statuses may be `adopt`, `ignore`, `defer`, `investigate`, or `intentional divergence`.
 
-9. Ensure the checkpoint label exists.
+6. Check whole-upstream watch sources.
 
-   The registry-level `checkpoint_label` defaults to `pac:upstream-checkpoint`. Before creating an issue, check for it:
-
-   ```bash
-   gh label list --json name --jq '.[].name'
-   ```
-
-   If it is missing and the user approved setup, create it:
+   For each `watch_sources` entry, list files under the watched paths at the current upstream head:
 
    ```bash
-   gh label create "pac:upstream-checkpoint" --description "pac artifact: upstream inspiration review checkpoint" --color "BFDADC"
+   git -C <checkout> ls-tree -r --name-only <current_head> -- <watch paths...>
    ```
 
-   If label creation fails, create the issue without the label and report the failure.
+   Compare this list against registered upstream refs for the same repository. Inventory review must be exhaustive for the requested watch scope:
 
-10. Create one checkpoint issue per run.
+   - List every uncovered upstream artifact path, not only notable examples.
+   - Group long inventories by category or directory, but do not replace the full list with `such as`, `etc.`, or similar shorthand.
+   - For initial baselines, call findings `currently uncovered` rather than `new` unless commit history proves when the asset appeared.
+   - For later checkpoints, distinguish `new`, `moved`, `removed`, and `still uncovered` paths when the previous baseline supports that distinction.
+   - If the list is too large for one compact bullet, include a nested list or collapsible-style Markdown section inside the checkpoint issue body.
+
+   A watch-source finding asks whether to create or update a local artifact entry, explicitly ignore coverage, or keep watching; it does not assume adoption.
+
+7. Ensure the checkpoint label exists.
+
+   Use the registry-level `checkpoint_label`, which defaults to `pac:upstream-checkpoint`. The current canonical label color is defined in `extensions/pac-setup-workflows/config.ts`. Create the label only when missing and setup is approved.
+
+   ```bash
+   repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+   checkpoint_label="$(awk -F': *' '$1 == "checkpoint_label" { print $2; found=1; exit } END { if (!found) print "pac:upstream-checkpoint" }' .pac/upstream-sources.yaml)"
+   if ! gh label list --repo "$repo" --json name --jq '.[].name' | grep -Fxq "$checkpoint_label"; then
+     # Run this create command only after the user approves setup.
+     gh label create "$checkpoint_label" --repo "$repo" --description "pac artifact: upstream inspiration review checkpoint" --color "C2E0C6"
+   fi
+   ```
+
+   The checkpoint issue marker remains `<!-- pac:upstream-checkpoint -->`; it is an artifact marker, not the configurable GitHub label name. If label creation fails, create the issue without the label and report the failure.
+
+8. Create one checkpoint issue per run when useful.
 
    Create a checkpoint issue when relevant changes, partial failures, or blocked sources are found. Use a title like:
 
@@ -183,13 +175,13 @@ Treat the registry as the current checkpoint, not the audit log. Treat GitHub ch
    Upstream inspiration checkpoint — YYYY-MM-DD
    ```
 
-   Issue body structure:
+   Body structure:
 
    ````md
    <!-- pac:upstream-checkpoint -->
    ## Summary
 
-   <one paragraph: relevant changes found / no relevant changes / partial failure>
+   <relevant changes found / no relevant changes / partial failure>
 
    ## Local artifacts reviewed
 
@@ -200,21 +192,19 @@ Treat the registry as the current checkpoint, not the audit log. Treat GitHub ch
 
    #### Upstream refs
 
-   - `<upstream-ref id>` (`<role/status>`): `<repo>@<ref>`
+   - `<upstream-ref id>` (`<role>/<status>/<sync_policy>`): `<repo>@<ref>`
      - Range: `<last commit or initial-baseline>..<current head>`
      - Paths: `<source paths>`
      - Previous checkpoint: `<issue or none>`
 
    #### Findings
 
-   List first-checkout findings as independently reviewable items. Use stable short IDs so the maintainer can review one finding or related group at a time.
-
    - [ ] `F-<n>` `<adopt|ignore|defer|investigate|intentional divergence>`: <finding and decision prompt>
    - No relevant upstream changes found.
 
    #### Notes for reviewers
 
-   - <known divergence, upstream-ref role interpretation, blocked context, or grouping suggestion>
+   - <known divergence, do-not-chase rule, blocked context, or sync-policy note>
 
    ## Watch sources reviewed
 
@@ -227,22 +217,28 @@ Treat the registry as the current checkpoint, not the audit log. Treat GitHub ch
 
    #### Inventory findings
 
-   - [ ] `W-<n>` `<investigate|intentional divergence>`: <new, moved, removed, or uncovered upstream asset and decision prompt>
+   - [ ] `W-<n>` `<investigate|intentional divergence>`: <inventory finding and decision prompt>
+     - Currently uncovered: `<complete path list, grouped if useful>`
+     - Suggested decision: <create/update local artifact entry | explicitly ignore | keep watching>
 
    ## Next checkpoint data
+
+   This is a summarized patch format. Apply each `local_artifacts` item to the matching `local_artifacts[].upstream_refs[]` entry's `last_reviewed`, and each `watch_sources` item to the matching `watch_sources[]` entry's `last_reviewed`.
 
    ```yaml
    local_artifacts:
      - id: <local artifact id>
        upstream_ref: <upstream-ref id>
-       commit: <current upstream head>
-       checkpoint_issue: <this issue URL>
-       reviewed_at: <ISO timestamp>
+       last_reviewed:
+         upstream_commit: <current upstream head>
+         checkpoint_issue: <this issue URL>
+         reviewed_at: <ISO timestamp>
    watch_sources:
      - id: <watch-source id>
-       commit: <current upstream head>
-       checkpoint_issue: <this issue URL>
-       reviewed_at: <ISO timestamp>
+       last_reviewed:
+         upstream_commit: <current upstream head>
+         checkpoint_issue: <this issue URL>
+         reviewed_at: <ISO timestamp>
    ```
 
    ## Notes
@@ -250,15 +246,15 @@ Treat the registry as the current checkpoint, not the audit log. Treat GitHub ch
    - Follow-up implementation issues should be created only after human confirmation.
    ````
 
-1. Do not advance `.pac/upstream-sources.yaml` automatically.
+9. Do not advance `.pac/upstream-sources.yaml` automatically.
 
-    After creating the issue, ask whether to update `last_reviewed` entries from the `Next checkpoint data`. Only update the registry after explicit confirmation that the checkpoint decisions are accepted. For local artifacts, update only the matching `upstream_refs[].last_reviewed` item, not the whole artifact. For watch sources, update only the matching `watch_sources[].last_reviewed` item.
+   After creating the issue, ask whether to update `last_reviewed` entries from the `Next checkpoint data`. Update only after explicit confirmation that the checkpoint baseline is accepted. If a later corrected checkpoint supersedes an earlier run, comment on both issues, close the stale checkpoint, and use only the accepted latest checkpoint data for baseline updates.
 
 ## No-change runs
 
 By default, do not create a checkpoint issue when no relevant upstream changes are found. Instead, report the result in the conversation and note that the checkpoint baseline is unchanged.
 
-If the user explicitly requests an issue even for no-change runs (for example with `--include-empty`), create a short checkpoint issue that makes the absence of relevant changes explicit. Do not create follow-up issues.
+If the user explicitly requests an issue even for no-change runs, create a short checkpoint issue that makes the absence of relevant changes explicit. Do not create follow-up issues.
 
 ## Examples
 
@@ -271,17 +267,11 @@ Review every registered local artifact and watch source:
 Review one local artifact only:
 
 ```text
-/pac-upstream-checkpoints pi-skills-agent-stuff-adaptations
+/pac-upstream-checkpoints pi-skill-github
 ```
 
-Review one whole-upstream watch source only:
+Review one watch source only:
 
 ```text
 /pac-upstream-checkpoints mattpocock-skills-watch
-```
-
-Initialize or repair the registry before running a review:
-
-```text
-/pac-upstream-checkpoints initialize registry
 ```

--- a/skills/pac-upstream-checkpoints/SKILL.md
+++ b/skills/pac-upstream-checkpoints/SKILL.md
@@ -29,24 +29,45 @@ Do not implement upstream changes from this workflow. Suggest follow-up areas an
 
 The registry lives at `.pac/upstream-sources.yaml`.
 
-Each source entry should include:
+The registry is local-first. Start from the artifact we maintain, then list the upstream refs that explain its provenance, current reference points, or reusable patterns.
 
-- `id`: stable machine-friendly source identifier
-- `title`: human-readable review unit
-- `kind`: component/workflow category
-- `source.repo`: upstream repository URL
-- `source.ref`: branch, tag, or ref to inspect
-- `source.paths`: upstream paths relevant to this review unit
-- `local.paths`: local files or directories that map to the upstream source
-- `attribution`: upstream credit, license notes, and provenance notes
-- `known_divergence`: intentional differences reviewers should not treat as defects
-- `last_reviewed`: current machine-readable checkpoint:
-  - `commit`: upstream commit from the last confirmed checkpoint, or `null` for initial setup
-  - `checkpoint_issue`: last checkpoint issue URL/number, or `null`
-  - `reviewed_at`: timestamp of the last confirmed checkpoint, or `null`
-  - `notes`: brief baseline notes
+Top-level fields:
 
-Treat the registry as the current checkpoint, not the audit log. Treat GitHub checkpoint issues as the full narrative and decision log.
+- `schema_version`: registry schema version.
+- `checkpoint_label`: GitHub label for checkpoint issues.
+- `local_artifacts`: local review units to check against upstream refs.
+- `watch_sources`: whole upstream inventories to watch for newly added, moved, or removed assets.
+
+Each `local_artifacts` entry should include:
+
+- `id`: stable machine-friendly local artifact identifier.
+- `title`: human-readable local review unit.
+- `kind`: component/workflow category.
+- `local.paths`: local files or directories that belong to this review unit.
+- `upstream_refs`: one or more upstream references for this local artifact.
+- `attribution`: upstream credit, license notes, and provenance notes for the local artifact.
+- `known_divergence`: intentional differences reviewers should not treat as defects.
+
+Each `upstream_refs` item should include:
+
+- `id`: stable machine-friendly upstream-ref identifier within the local artifact.
+- `role`: why this upstream matters, such as `original_provenance`, `current_reference`, `source_adaptation`, `pattern_source`, `historical`, or `watch_only`.
+- `status`: review posture, such as `active`, `historical`, `watch_only`, or `retired`.
+- `repo`, `ref`, and `paths`: upstream repository, ref, and paths for that upstream ref.
+- `attribution`: credit, license, and provenance notes specific to that upstream ref when useful.
+- `last_reviewed`: checkpoint data for that upstream ref:
+  - `commit`: upstream commit from the last confirmed checkpoint, or `null` for initial setup.
+  - `checkpoint_issue`: last checkpoint issue URL/number, or `null`.
+  - `reviewed_at`: timestamp of the last confirmed checkpoint, or `null`.
+  - `notes`: brief baseline notes.
+
+Each `watch_sources` entry should include:
+
+- `id`, `title`, `repo`, `ref`, and `paths`: the upstream inventory to scan.
+- `purpose`: why this inventory is watched and what kind of newly discovered assets should be flagged.
+- `last_reviewed`: checkpoint data for the inventory scan.
+
+Treat the registry as the current checkpoint, not the audit log. Treat GitHub checkpoint issues as the full narrative and decision log. Do not advance any `last_reviewed` field unless a human explicitly accepts the checkpoint baseline.
 
 ## Workflow
 
@@ -63,18 +84,22 @@ Treat the registry as the current checkpoint, not the audit log. Treat GitHub ch
 2. Read `.pac/upstream-sources.yaml`.
 
    - If the file is missing, stop and ask whether to initialize it.
-   - Validate that each entry has the required fields above.
-   - If a field is unknown or missing, report the exact source ID and continue only if the missing value is not needed for the requested scope.
+   - Validate each `local_artifacts` entry has the required fields above.
+   - Validate each `upstream_refs` item has `id`, `role`, `status`, `repo`, `ref`, `paths`, and `last_reviewed`.
+   - Validate each `watch_sources` entry has `id`, `title`, `repo`, `ref`, `paths`, `purpose`, and `last_reviewed`.
+   - If a field is unknown or missing, report the exact local artifact ID, upstream-ref ID, or watch-source ID; continue only if the missing value is not needed for the requested scope.
 
-3. Resolve source scope.
+3. Resolve review scope.
 
-   - If the user named one source ID, review only that source.
-   - Otherwise review every source entry.
-   - For initial entries with `last_reviewed.commit: null`, compare the current upstream head with the local mapped files and mark the range as `initial-baseline` instead of inventing a previous commit.
+   - If the user named one local artifact ID, review that local artifact and its upstream refs.
+   - If the user named one upstream-ref ID inside a local artifact, review only that upstream ref and its local mapping.
+   - If the user named one watch-source ID, run only that inventory watch.
+   - Otherwise review every local artifact and every watch source.
+   - For initial upstream refs or watch sources with `last_reviewed.commit: null`, compare the current upstream head with the local mapped files or inventory and mark the range as `initial-baseline` instead of inventing a previous commit.
 
 4. Fetch or refresh upstream repositories.
 
-   Prefer `pac-librarian` for GitHub repositories so future runs reuse cached checkouts. For each source:
+   Prefer `pac-librarian` for GitHub repositories so future runs reuse cached checkouts. For each upstream ref or watch source:
 
    ```bash
    bash skills/pac-librarian/checkout.sh <owner>/<repo> --path-only
@@ -85,11 +110,11 @@ Treat the registry as the current checkpoint, not the audit log. Treat GitHub ch
 
    `pac-librarian` creates shallow clones by default. Run `fetch --unshallow` first so that commit-range comparisons against older `last_reviewed` commits succeed.
 
-   If a source is not a Git repository or cannot be fetched, record the access failure in the checkpoint findings.
+   If an upstream ref is not a Git repository or cannot be fetched, record the access failure in the checkpoint findings for that review unit.
 
 5. Walk upstream commit history before raw file comparison.
 
-   For each source with a previous commit:
+   For each upstream ref or watch source with a previous commit:
 
    ```bash
    git -C <checkout> log --oneline --decorate <last_reviewed_commit>..<current_head> -- <source paths...>
@@ -105,17 +130,19 @@ Treat the registry as the current checkpoint, not the audit log. Treat GitHub ch
    - process, prompt-design, or authoring convention improvements,
    - commits whose rationale is unclear from the diff alone.
 
-6. Discover new upstream assets not yet in the registry.
+   For local artifacts with multiple upstream refs, compare each ref according to its `role` and `status`. For example, check `current_reference` refs for concrete improvements, while treating `original_provenance` or `historical` refs as provenance unless they contain a materially new idea.
 
-   For each source, derive the parent directories from `source.paths` (for example `extensions/` and `skills/`) and list all files under those directories at the current upstream head:
+6. Check whole-upstream watch sources for new assets.
+
+   For each `watch_sources` entry, list all files under its watched paths at the current upstream head:
 
    ```bash
-   git -C <checkout> ls-tree -r --name-only <ref> -- <parent dirs...>
+   git -C <checkout> ls-tree -r --name-only <ref> -- <watch paths...>
    ```
 
-   Compare this list against the union of `source.paths` across all registry entries for the same repository. Flag any paths that are not covered by an existing entry as potential new upstream assets. Include these in the checkpoint findings with a suggested status of `investigate` so a maintainer can decide whether to add them to the registry.
+   Compare this list against the union of registered `upstream_refs[].paths` for the same repository. Flag newly added, moved, removed, or uncovered paths as inventory findings with suggested status `investigate` or `intentional divergence`. A watch-source finding should ask whether to create or update a local artifact entry, not assume adoption.
 
-   Skip this step when the source uses the `documentation-pattern` kind or when the upstream paths are individual files rather than directory-scoped.
+   Use watch sources for broad discovery. Keep local artifact reviews focused on the upstream refs already mapped to that artifact.
 
 7. Pull linked upstream PRs/issues selectively.
 
@@ -164,29 +191,55 @@ Treat the registry as the current checkpoint, not the audit log. Treat GitHub ch
 
    <one paragraph: relevant changes found / no relevant changes / partial failure>
 
-   ## Sources reviewed
+   ## Local artifacts reviewed
 
-   ### <source id> — <title>
+   ### <local artifact id> — <title>
 
-   - Upstream: <repo>@<ref>
-   - Range: <last commit or initial-baseline>..<current head>
    - Local mapping: <paths>
-   - Previous checkpoint: <issue or none>
    - Result: <changes found | no relevant changes | blocked | partial>
+
+   #### Upstream refs
+
+   - `<upstream-ref id>` (`<role/status>`): `<repo>@<ref>`
+     - Range: `<last commit or initial-baseline>..<current head>`
+     - Paths: `<source paths>`
+     - Previous checkpoint: `<issue or none>`
 
    #### Findings
 
-   - <finding, or "No relevant upstream changes found.">
+   List first-checkout findings as independently reviewable items. Use stable short IDs so the maintainer can review one finding or related group at a time.
 
-   #### Suggested decisions
+   - [ ] `F-<n>` `<adopt|ignore|defer|investigate|intentional divergence>`: <finding and decision prompt>
+   - No relevant upstream changes found.
 
-   - [ ] <adopt|ignore|defer|investigate|intentional divergence>: <decision prompt>
+   #### Notes for reviewers
+
+   - <known divergence, upstream-ref role interpretation, blocked context, or grouping suggestion>
+
+   ## Watch sources reviewed
+
+   ### <watch-source id> — <title>
+
+   - Upstream: `<repo>@<ref>`
+   - Range: `<last commit or initial-baseline>..<current head>`
+   - Watched paths: <paths>
+   - Result: <new assets found | no inventory changes | blocked | partial>
+
+   #### Inventory findings
+
+   - [ ] `W-<n>` `<investigate|intentional divergence>`: <new, moved, removed, or uncovered upstream asset and decision prompt>
 
    ## Next checkpoint data
 
    ```yaml
-   sources:
-     - id: <source id>
+   local_artifacts:
+     - id: <local artifact id>
+       upstream_ref: <upstream-ref id>
+       commit: <current upstream head>
+       checkpoint_issue: <this issue URL>
+       reviewed_at: <ISO timestamp>
+   watch_sources:
+     - id: <watch-source id>
        commit: <current upstream head>
        checkpoint_issue: <this issue URL>
        reviewed_at: <ISO timestamp>
@@ -199,7 +252,7 @@ Treat the registry as the current checkpoint, not the audit log. Treat GitHub ch
 
 1. Do not advance `.pac/upstream-sources.yaml` automatically.
 
-    After creating the issue, ask whether to update `last_reviewed` entries from the `Next checkpoint data`. Only update the registry after explicit confirmation that the checkpoint decisions are accepted.
+    After creating the issue, ask whether to update `last_reviewed` entries from the `Next checkpoint data`. Only update the registry after explicit confirmation that the checkpoint decisions are accepted. For local artifacts, update only the matching `upstream_refs[].last_reviewed` item, not the whole artifact. For watch sources, update only the matching `watch_sources[].last_reviewed` item.
 
 ## No-change runs
 
@@ -209,16 +262,22 @@ If the user explicitly requests an issue even for no-change runs (for example wi
 
 ## Examples
 
-Review every registered source:
+Review every registered local artifact and watch source:
 
 ```text
 /pac-upstream-checkpoints
 ```
 
-Review one source only:
+Review one local artifact only:
 
 ```text
-/pac-upstream-checkpoints agent-stuff-pi-skills
+/pac-upstream-checkpoints pi-skills-agent-stuff-adaptations
+```
+
+Review one whole-upstream watch source only:
+
+```text
+/pac-upstream-checkpoints mattpocock-skills-watch
 ```
 
 Initialize or repair the registry before running a review:


### PR DESCRIPTION
Add a registry, skill, prompt, and managed label for reviewing borrowed upstream sources through auditable checkpoint issues.

Verification: npm test; npm run typecheck

closes #192
