### PR TITLE
✨ feat(notify): Add ready-for-input terminal notifications

### DIFF
--- a/.pac/upstream-sources.yaml
+++ b/.pac/upstream-sources.yaml
@@ -131,6 +131,37 @@ local_artifacts:
     known_divergence:
       - Local extension layout may differ from upstream single-file extension layout.
 
+  - id: pi-extension-notify
+    title: Notify extension
+    kind: extension
+    local:
+      paths:
+        - extensions/notify/
+    upstream_refs:
+      - id: agent-stuff-notify-extension
+        role: source_adaptation
+        status: active
+        sync_policy: targeted
+        repo: https://github.com/mitsuhiko/agent-stuff
+        ref: main
+        paths:
+          - extensions/notify.ts
+        attribution:
+          upstream: mitsuhiko/agent-stuff/extensions/notify.ts
+          license: Review upstream repository before copying new code.
+          notes: Local extension may be split into helper modules and tests to satisfy mypac extension layout rules.
+        last_reviewed:
+          upstream_commit: ab79f98104bcd3c6a7c5491e609f6d6700a7414d
+          checkpoint_issue: https://github.com/ladislas/mypac/issues/227
+          reviewed_at: 2026-05-20T06:57:03Z
+          notes: "Baseline accepted from upstream checkpoint #227."
+    attribution:
+      upstream: mitsuhiko/agent-stuff
+      license: Review upstream repository before copying new code.
+      notes: Local file includes original-source credit; README gives broad credit.
+    known_divergence:
+      - Local extension layout differs from upstream single-file extension layout to allow tested helper modules.
+
   - id: pi-extension-todos
     title: Todos extension
     kind: extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioned sections should match the Git tags and GitHub releases published for t
 
 ### Added
 
+- Added a `notify` Pi extension that sends terminal notifications with the latest assistant response summary when Pi is ready for input, using terminal-specific OSC sequences with OSC 777 as the fallback. ([#236](https://github.com/ladislas/mypac/issues/236))
 - Added `.pac/upstream-sources.yaml`, `pac-upstream-checkpoints`, and `/pac-upstream-checkpoints` for reviewing borrowed upstream sources, tracking local artifacts, and creating checkpoint issues. ([#192](https://github.com/ladislas/mypac/issues/192))
 - Added `pac-tdd` as a standalone pragmatic TDD skill with lightweight notes for tests, mocking, refactoring, deep modules, and interface design. ([#155](https://github.com/ladislas/mypac/issues/155))
 - Added this changelog to track notable repository changes and future GitHub releases. ([#139](https://github.com/ladislas/mypac/issues/139))

--- a/extensions/notify/helpers.ts
+++ b/extensions/notify/helpers.ts
@@ -1,0 +1,137 @@
+import { Markdown, type MarkdownTheme } from "@earendil-works/pi-tui";
+
+export type NotifyMessage = {
+	role?: string;
+	content?: unknown;
+};
+
+const isTextPart = (part: unknown): part is { type: "text"; text: string } =>
+	Boolean(
+		part &&
+			typeof part === "object" &&
+			"type" in part &&
+			part.type === "text" &&
+			"text" in part &&
+			typeof part.text === "string",
+	);
+
+export function extractLastAssistantText(messages: NotifyMessage[]): string | null {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const message = messages[i];
+		if (message?.role !== "assistant") {
+			continue;
+		}
+
+		const content = message.content;
+		if (typeof content === "string") {
+			const text = content.trim();
+			if (text) {
+				return text;
+			}
+			continue;
+		}
+
+		if (Array.isArray(content)) {
+			const text = content
+				.filter(isTextPart)
+				.map((part) => part.text)
+				.join("\n")
+				.trim();
+			if (text) {
+				return text;
+			}
+			continue;
+		}
+
+		continue;
+	}
+
+	return null;
+}
+
+const plainMarkdownTheme: MarkdownTheme = {
+	heading: (text) => text,
+	link: (text) => text,
+	linkUrl: () => "",
+	code: (text) => text,
+	codeBlock: (text) => text,
+	codeBlockBorder: () => "",
+	quote: (text) => text,
+	quoteBorder: () => "",
+	hr: () => "",
+	listBullet: () => "",
+	bold: (text) => text,
+	italic: (text) => text,
+	strikethrough: (text) => text,
+	underline: (text) => text,
+};
+
+function wrapPlainText(text: string, width: number): string {
+	return text
+		.split("\n")
+		.flatMap((line) => {
+			if (!line) return [""];
+			const wrapped: string[] = [];
+			for (let i = 0; i < line.length; i += width) {
+				wrapped.push(line.slice(i, i + width));
+			}
+			return wrapped.length > 0 ? wrapped : [""];
+		})
+		.join("\n");
+}
+
+function simpleMarkdown(text: string, width = 80): string {
+	try {
+		const markdown = new Markdown(text, 0, 0, plainMarkdownTheme);
+		return markdown.render(width).join("\n");
+	} catch {
+		return wrapPlainText(text, width);
+	}
+}
+
+export function formatNotification(text: string | null): { title: string; body: string } {
+	const simplified = text ? simpleMarkdown(text) : "";
+	const normalized = simplified.replace(/\s+/g, " ").trim();
+	if (!normalized) {
+		return { title: "Ready for input", body: "" };
+	}
+
+	const maxBody = 200;
+	const body = normalized.length > maxBody ? `${normalized.slice(0, maxBody - 1)}…` : normalized;
+	return { title: "π", body };
+}
+
+type NotifyEnv = Partial<
+	Pick<NodeJS.ProcessEnv, "ITERM_SESSION_ID" | "KITTY_WINDOW_ID" | "TERM_PROGRAM" | "TMUX">
+>;
+
+function wrapForTmux(sequence: string, env: NotifyEnv): string {
+	if (!env.TMUX) {
+		return sequence;
+	}
+
+	const escaped = sequence.split("\x1b").join("\x1b\x1b");
+	return `\x1bPtmux;${escaped}\x1b\\`;
+}
+
+function sanitizeNotificationField(value: string): string {
+	return value.replace(/[\x00-\x1f\x7f]/g, "").replace(/;/g, ",");
+}
+
+export function formatTerminalNotification(title: string, body: string, env: NotifyEnv = process.env): string {
+	const safeTitle = sanitizeNotificationField(title);
+	const safeBody = sanitizeNotificationField(body);
+
+	if (env.KITTY_WINDOW_ID) {
+		const titleSequence = `\x1b]99;i=1:d=0;${safeTitle}\x1b\\`;
+		const bodySequence = `\x1b]99;i=1:p=body;${safeBody}\x1b\\`;
+		return wrapForTmux(titleSequence, env) + wrapForTmux(bodySequence, env);
+	}
+
+	if (env.TERM_PROGRAM === "iTerm.app" || env.ITERM_SESSION_ID) {
+		const message = safeBody ? `${safeTitle}: ${safeBody}` : safeTitle;
+		return wrapForTmux(`\x1b]9;${message}\x07`, env);
+	}
+
+	return wrapForTmux(`\x1b]777;notify;${safeTitle};${safeBody}\x07`, env);
+}

--- a/extensions/notify/index.ts
+++ b/extensions/notify/index.ts
@@ -1,0 +1,56 @@
+/**
+ * Original source: https://github.com/mitsuhiko/agent-stuff/blob/main/extensions/notify.ts
+ * Additional reference: https://github.com/ferologics/pi-notify/blob/master/index.ts
+ *
+ * Sends a terminal desktop notification when Pi is ready for input.
+ * Supports iTerm2 OSC 9, Kitty OSC 99, tmux passthrough, and OSC 777 for
+ * Ghostty, WezTerm, and rxvt-unicode. Also supports an optional
+ * PI_NOTIFY_SOUND_CMD hook.
+ *
+ * Intentional local adaptation: helper logic lives in ./helpers.ts so message
+ * extraction and notification formatting can be tested in isolation.
+ */
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { spawn } from "node:child_process";
+import { extractLastAssistantText, formatNotification, formatTerminalNotification } from "./helpers.ts";
+
+function runSoundHook(): void {
+	const command = process.env.PI_NOTIFY_SOUND_CMD?.trim();
+	if (!command) {
+		return;
+	}
+
+	try {
+		const child = spawn(command, {
+			shell: true,
+			detached: true,
+			stdio: "ignore",
+		});
+		child.on("error", () => {
+			// Ignore hook errors to avoid breaking notifications.
+		});
+		child.unref();
+	} catch {
+		// Ignore hook errors to avoid breaking notifications.
+	}
+}
+
+function notify(title: string, body: string): void {
+	process.stdout.write(formatTerminalNotification(title, body));
+	runSoundHook();
+}
+
+export default function (pi: ExtensionAPI) {
+	pi.registerCommand("notify-test", {
+		description: "Send a test terminal notification",
+		handler: async () => {
+			notify("Pi test", "Ready for input");
+		},
+	});
+
+	pi.on("agent_end", async (event) => {
+		const lastText = extractLastAssistantText(event.messages ?? []);
+		const { title, body } = formatNotification(lastText);
+		notify(title, body);
+	});
+}

--- a/extensions/notify/notify.test.mjs
+++ b/extensions/notify/notify.test.mjs
@@ -1,0 +1,111 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { extractLastAssistantText, formatNotification, formatTerminalNotification } from "./helpers.ts";
+
+test("extracts the last assistant string content", () => {
+	const text = extractLastAssistantText([
+		{ role: "assistant", content: "first" },
+		{ role: "user", content: "question" },
+		{ role: "assistant", content: "  final answer  " },
+	]);
+
+	assert.equal(text, "final answer");
+});
+
+test("extracts text parts from the last assistant array content", () => {
+	const text = extractLastAssistantText([
+		{
+			role: "assistant",
+			content: [
+				{ type: "thinking", text: "ignore me" },
+				{ type: "text", text: "line one" },
+				{ type: "text", text: "line two" },
+			],
+		},
+	]);
+
+	assert.equal(text, "line one\nline two");
+});
+
+test("returns null when no assistant text is available", () => {
+	assert.equal(extractLastAssistantText([{ role: "user", content: "hello" }]), null);
+	assert.equal(extractLastAssistantText([{ role: "assistant", content: "   " }]), null);
+});
+
+test("skips assistant messages without extractable text", () => {
+	const text = extractLastAssistantText([
+		{ role: "assistant", content: "usable answer" },
+		{ role: "assistant", content: [{ type: "tool-call", name: "bash" }] },
+		{ role: "assistant", content: { type: "other" } },
+	]);
+
+	assert.equal(text, "usable answer");
+});
+
+test("formats empty text as a ready-for-input notification", () => {
+	assert.deepEqual(formatNotification(null), { title: "Ready for input", body: "" });
+});
+
+test("formats markdown-like assistant text as a normalized notification body", () => {
+	const notification = formatNotification("## Done\n\nThis is **ready** now.\n\n- Item one\n- Item two");
+
+	assert.equal(notification.title, "π");
+	assert.equal(notification.body, "Done This is ready now. Item one Item two");
+});
+
+test("truncates long notification bodies", () => {
+	const notification = formatNotification("x".repeat(250));
+
+	assert.equal(notification.body.length, 200);
+	assert.equal(notification.body.endsWith("…"), true);
+});
+
+test("formats iTerm2 notifications with OSC 9", () => {
+	assert.equal(
+		formatTerminalNotification("Pi test", "Ready for input", { TERM_PROGRAM: "iTerm.app" }),
+		"\x1b]9;Pi test: Ready for input\x07",
+	);
+});
+
+test("formats default notifications with OSC 777", () => {
+	assert.equal(
+		formatTerminalNotification("π", "Ready for input", {}),
+		"\x1b]777;notify;π;Ready for input\x07",
+	);
+});
+
+test("detects iTerm2 from ITERM_SESSION_ID", () => {
+	assert.equal(
+		formatTerminalNotification("Pi test", "Ready for input", { ITERM_SESSION_ID: "session" }),
+		"\x1b]9;Pi test: Ready for input\x07",
+	);
+});
+
+test("formats Kitty notifications with OSC 99", () => {
+	assert.equal(
+		formatTerminalNotification("Pi test", "Ready for input", { KITTY_WINDOW_ID: "1" }),
+		"\x1b]99;i=1:d=0;Pi test\x1b\\\x1b]99;i=1:p=body;Ready for input\x1b\\",
+	);
+});
+
+test("wraps notifications for tmux passthrough", () => {
+	assert.equal(
+		formatTerminalNotification("Pi test", "Ready for input", { TERM_PROGRAM: "iTerm.app", TMUX: "/tmp/tmux" }),
+		"\x1bPtmux;\x1b\x1b]9;Pi test: Ready for input\x07\x1b\\",
+	);
+});
+
+test("sanitizes notification fields before formatting OSC sequences", () => {
+	assert.equal(
+		formatTerminalNotification("P;i\x07", "Ready\x1b]9;bad\x07;done", {}),
+		"\x1b]777;notify;P,i;Ready]9,bad,done\x07",
+	);
+	assert.equal(
+		formatTerminalNotification("P;i\x07", "Ready\x1b]9;bad\x07;done", { TERM_PROGRAM: "iTerm.app" }),
+		"\x1b]9;P,i: Ready]9,bad,done\x07",
+	);
+	assert.equal(
+		formatTerminalNotification("P;i\x07", "Ready\x1b]9;bad\x07;done", { KITTY_WINDOW_ID: "1" }),
+		"\x1b]99;i=1:d=0;P,i\x1b\\\x1b]99;i=1:p=body;Ready]9,bad,done\x1b\\",
+	);
+});


### PR DESCRIPTION
## Summary

- Add a local `notify` Pi extension adapted from Agent Stuff
- Send OSC 777 terminal notifications when Pi is ready for input
- Add focused tests for assistant text extraction and notification formatting
- Update the changelog

## Verification

- `node --experimental-strip-types --test extensions/notify/notify.test.mjs`
- `npm test`
- `npm run typecheck`

closes #236