### PR TITLE
📝 docs(grill-with-docs): Clarify upstream-inspired questioning guidance

### DIFF
--- a/.pac/upstream-sources.yaml
+++ b/.pac/upstream-sources.yaml
@@ -871,8 +871,11 @@ local_artifacts:
     known_divergence:
       - mypac PRD artifacts use hidden markers and GitHub-native context links.
       - mypac grill-with-docs includes a PRD companion format and pac-specific GitHub issue persistence rules.
+      - "Per #234, mypac keeps ADRs as GitHub issue comments instead of upstream-style repo-local docs/adr files."
+      - "Per #234, mypac updates CONTEXT.md sparingly after proposing exact edits, instead of upstream-style inline updates."
     do_not_chase:
       - "Per #135, do not reopen every previously decided Matt Pocock skill adaptation during path repair."
+      - "Per #234, do not adopt upstream CONTEXT-MAP.md or multi-context structure until a concrete local need appears."
 
 watch_sources:
   - id: agent-stuff-extensions-watch

--- a/skills/pac-grill-with-docs/SKILL.md
+++ b/skills/pac-grill-with-docs/SKILL.md
@@ -85,9 +85,10 @@ Keep one repo-root `CONTEXT.md` for stable reusable project language, invariants
 
 - Ask one question at a time.
 - Give a recommended answer with each question.
-- Challenge fuzzy or overloaded terms.
-- Cross-check claims against the codebase and issue history.
-- Use concrete scenarios to test boundaries.
+- Challenge fuzzy or overloaded terms; propose a precise project term when the user says something ambiguous.
+- Check existing `CONTEXT.md` language when relevant, and call out conflicts between the user's wording and established glossary terms.
+- Cross-check claims against the codebase and issue history; surface contradictions plainly when code behavior differs from the stated plan.
+- Use concrete scenarios to test boundaries and relationships between concepts.
 - Stop when uncertainty is low enough to choose the next action. Do not ask 100 questions for a tiny clear fix.
 
 ## Before writing back


### PR DESCRIPTION
Adopt the useful glossary, scenario, and code-contradiction checks from upstream while keeping the local GitHub-native persistence model and sparing CONTEXT.md update behavior.

Verification: git diff --check

closes #234
