### PR TITLE
✨ feat(review): Add optional standards/spec follow-up guidance

### DIFF
--- a/.pac/upstream-sources.yaml
+++ b/.pac/upstream-sources.yaml
@@ -357,6 +357,41 @@ local_artifacts:
       - "Per #118 and PR #190, do not chase wholesale feature parity with upstream review implementations."
       - Missing upstream loop-fixing, custom-persistence, broad local-changes review, or other removed complexity is intentional unless a concrete prompt, rubric, bugfix, or robustness change is identified.
 
+  - id: pac-review-standards-spec-skill
+    title: Standards + Spec review skill
+    kind: skill
+    local:
+      paths:
+        - skills/pac-review-standards-spec/
+    upstream_refs:
+      - id: mattpocock-review-two-axis-skill
+        role: current_reference
+        status: active
+        sync_policy: targeted
+        repo: https://github.com/mattpocock/skills
+        ref: main
+        paths:
+          - skills/in-progress/review/SKILL.md
+        attribution:
+          upstream: mattpocock/skills/skills/in-progress/review/SKILL.md
+          license: Review upstream repository before copying new text or structure.
+          notes: Local guidance adapts upstream Standards and Spec review axes as an optional follow-up to pac-review.
+        last_reviewed:
+          upstream_commit: e74f0061bb67222181640effa98c675bdb2fdaa7
+          checkpoint_issue: https://github.com/ladislas/mypac/issues/255
+          reviewed_at: 2026-05-21T09:39:13Z
+          notes: "Registered from #255 after adapting upstream's two-axis review concept into an optional follow-up skill."
+    attribution:
+      upstream: mattpocock/skills
+      license: Review upstream repository before copying new text or structure.
+      notes: Local skill adapts upstream Standards and Spec review axes to mypac's default review workflow.
+    known_divergence:
+      - Local Standards + Spec review is optional and separate from the default pac-review defect-oriented pass.
+      - Local summaries preserve default, Standards, and Spec findings as separate sections for /review-end handoff.
+    do_not_chase:
+      - "Per #255, do not replace the default pac-review rubric with the upstream two-axis review structure."
+      - "Do not add mandatory UI presets or sub-agent support unless a concrete local need is identified."
+
   - id: pi-skill-commit
     title: Commit skill
     kind: skill

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioned sections should match the Git tags and GitHub releases published for t
 
 ### Added
 
+- Added optional Standards + Spec follow-up review support with a dedicated `pac-review-standards-spec` skill and `/review-end` summaries that preserve default, standards, and spec findings separately. ([#255](https://github.com/ladislas/mypac/issues/255))
 - Added `/pac-fix-copilot-review` for addressing GitHub Copilot PR review comments with explicit fixup commits and resolved review threads. ([#246](https://github.com/ladislas/mypac/issues/246))
 - Added a `notify` Pi extension that sends terminal notifications with the latest assistant response summary when Pi is ready for input, using terminal-specific OSC sequences with OSC 777 as the fallback. ([#236](https://github.com/ladislas/mypac/issues/236))
 - Added `.pac/upstream-sources.yaml`, `pac-upstream-checkpoints`, and `/pac-upstream-checkpoints` for reviewing borrowed upstream sources, tracking local artifacts, and creating checkpoint issues. ([#192](https://github.com/ladislas/mypac/issues/192))

--- a/extensions/review/REVIEW_FIX_FINDINGS_PROMPT.md
+++ b/extensions/review/REVIEW_FIX_FINDINGS_PROMPT.md
@@ -11,7 +11,7 @@ Do not inspect repository history to switch workflows mid-run.
 
 ## Fix instructions
 
-1. Treat the summary's Findings/Fix Queue as a checklist.
+1. Treat the summary's Default Review Findings, Standards Findings, Spec Findings, and Combined Fix Queue sections as a checklist.
 2. Fix in priority order: P0, P1, then P2 (include P3 if quick and safe).
 3. If a finding is invalid/already fixed/not possible right now, briefly explain why and continue.
 4. Treat "Human Reviewer Callouts (Non-Blocking)" as informational only; do not convert them into fix tasks unless there is a separate explicit finding.

--- a/extensions/review/REVIEW_SUMMARY_PROMPT.md
+++ b/extensions/review/REVIEW_SUMMARY_PROMPT.md
@@ -6,6 +6,8 @@ Create a structured handoff that can be used immediately to implement fixes.
 You MUST summarize the review that happened in this session so findings can be acted on.
 Do not omit findings: include every actionable issue that was identified.
 
+If the session included multiple review passes (for example a default review plus Standards and Spec follow-up passes), preserve those findings in separate sections. Do not flatten Standards or Spec findings into the default findings.
+
 Required sections (in order):
 
 ## Review Scope
@@ -16,18 +18,32 @@ Required sections (in order):
 
 - "correct" or "needs attention"
 
-## Findings
+## Default Review Findings
 
-For EACH finding, include:
+Include findings from the default defect-oriented review pass. For EACH finding, include:
 
 - Priority tag ([P0]..[P3]) and short title
 - File location (`path/to/file.ext:line`)
 - Why it matters (brief)
 - What should change (brief, actionable)
 
-## Fix Queue
+If no default findings were identified, write "- (none)".
 
-1. Ordered implementation checklist (highest priority first)
+## Standards Findings
+
+Include findings from any Standards follow-up pass separately from default review findings. If no Standards pass occurred, write "- Not run." If it ran and found no issues, write "- (none)".
+
+For EACH Standards finding, include the same finding fields as above plus the relevant standards source when available.
+
+## Spec Findings
+
+Include findings from any Spec follow-up pass separately from default review findings. If no Spec pass occurred, write "- Not run." If it ran and found no issues, write "- (none)".
+
+For EACH Spec finding, include the same finding fields as above plus the spec source when available. If the Spec pass could not identify a source, preserve that note.
+
+## Combined Fix Queue
+
+1. Ordered implementation checklist across all findings (highest priority first)
 
 ## Constraints & Preferences
 

--- a/extensions/review/prompts.test.mjs
+++ b/extensions/review/prompts.test.mjs
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import {
 	loadMarkdownReviewPrompt,
+	loadReviewSummaryPrompt,
 	ReviewPromptLoadError,
 	stripPromptMarkdownTitle,
 } from "./prompts.ts";
@@ -37,4 +38,14 @@ test("loadMarkdownReviewPrompt reports missing Markdown prompt files clearly", a
 			return true;
 		},
 	);
+});
+
+test("review summary prompt preserves separate review passes", async () => {
+	const prompt = await loadReviewSummaryPrompt();
+
+	assert.match(prompt, /## Default Review Findings/);
+	assert.match(prompt, /## Standards Findings/);
+	assert.match(prompt, /## Spec Findings/);
+	assert.match(prompt, /## Combined Fix Queue/);
+	assert.match(prompt, /preserve.*separate/i);
 });

--- a/skills/pac-review-standards-spec/SKILL.md
+++ b/skills/pac-review-standards-spec/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: pac-review-standards-spec
+description: "Run an optional Standards + Spec follow-up review after the default pac-review pass. Use when the user asks for a standards review, spec review, or Standards + Spec review of code changes."
+license: MIT
+compatibility: Git repository; gh CLI required for pull request reviews.
+metadata:
+  author: mypac
+  stage: shared
+---
+
+# Standards + Spec Review
+
+Use this skill only as an optional follow-up to the default `pac-review` defect-oriented review pass. Do not replace or weaken the default review rubric.
+
+Keep the results separate from default review findings with these sections:
+
+```md
+## Standards Findings
+...
+
+## Spec Findings
+...
+```
+
+## Standards pass
+
+Evaluate whether the diff follows documented repository standards. Look for relevant sources such as:
+
+- `AGENTS.md` and nested agent/instruction files that apply to the changed paths
+- `CONTRIBUTING.md`, `CONTEXT.md`, README guidance, and docs that define contributor or project conventions
+- ADRs or decision records that constrain the changed area
+- Tooling/config files that express repository policy, such as linters, formatters, TypeScript config, test config, CI workflows, package scripts, or dependency policy files
+
+Do not spend findings on rules that machines already enforce unless the diff bypasses or weakens that enforcement. Flag only standards mismatches that are actionable, introduced by the diff, and likely worth fixing.
+
+For each Standards finding, cite the relevant standards source. If no relevant standards source exists, say so and keep the pass brief.
+
+## Spec pass
+
+Evaluate whether the diff matches the originating issue, PRD, ADR, design note, PR description, or user-provided spec.
+
+First identify the best available spec source from the review context, including issue/PR links, `closes #...` references, PR body references, linked PRD comments, ADR comments, or explicit user instructions. Prefer the newest linked PRD/comment that actually contains the expected structured marker when those artifacts exist. Treat ADRs and explicit decisions as constraints.
+
+If no spec source is available, clearly say that and do not invent requirements. If a spec source is stale, unreadable, or missing the expected marker, say so plainly and use the minimum direct context available.
+
+For each Spec finding, cite the spec source and explain the mismatch. Keep Spec findings separate from Standards and default review findings.
+
+## Output
+
+Report Standards and Spec findings separately. Use the same priority tags and finding quality bar as `pac-review`: only flag actionable issues introduced by the reviewed diff that the author would likely fix if aware of them.
+
+If a pass was not possible, say why under that pass heading instead of inventing requirements or standards.

--- a/skills/pac-review/SKILL.md
+++ b/skills/pac-review/SKILL.md
@@ -159,6 +159,43 @@ Provide your findings in a clear, structured format:
 
 Output all findings the author would fix if they knew about them. If there are no qualifying findings, explicitly state the code looks good. Don't stop at the first finding — list every qualifying issue. Then append the required non-blocking callouts section.
 
+## Optional Standards + Spec follow-up review
+
+Only run this pass when the user explicitly asks for a Standards + Spec review, or asks for one of those axes after the default review. Do not replace or weaken the default defect-oriented review rubric above.
+
+Keep the results separate from default review findings with these sections:
+
+```md
+## Standards Findings
+...
+
+## Spec Findings
+...
+```
+
+### Standards pass
+
+Evaluate whether the diff follows documented repository standards. Look for relevant sources such as:
+
+- `AGENTS.md` and nested agent/instruction files that apply to the changed paths
+- `CONTRIBUTING.md`, `CONTEXT.md`, README guidance, and docs that define contributor or project conventions
+- ADRs or decision records that constrain the changed area
+- Tooling/config files that express repository policy, such as linters, formatters, TypeScript config, test config, CI workflows, package scripts, or dependency policy files
+
+Do not spend findings on rules that machines already enforce unless the diff bypasses or weakens that enforcement. Flag only standards mismatches that are actionable, introduced by the diff, and likely worth fixing.
+
+For each Standards finding, cite the relevant standards source. If no relevant standards source exists, say so and keep the pass brief.
+
+### Spec pass
+
+Evaluate whether the diff matches the originating issue, PRD, ADR, design note, PR description, or user-provided spec.
+
+First identify the best available spec source from the review context, including issue/PR links, `closes #...` references, PR body references, linked PRD comments, ADR comments, or explicit user instructions. Prefer the newest linked PRD/comment that actually contains the expected structured marker when those artifacts exist. Treat ADRs and explicit decisions as constraints.
+
+If no spec source is available, clearly say that and do not invent requirements. If a spec source is stale, unreadable, or missing the expected marker, say so plainly and use the minimum direct context available.
+
+For each Spec finding, cite the spec source and explain the mismatch. Keep Spec findings separate from Standards and default review findings.
+
 ## Fix session commit discipline
 
 When applying fixes during a review fix pass (via `/review-end` → "Return and fix findings"):

--- a/skills/pac-review/SKILL.md
+++ b/skills/pac-review/SKILL.md
@@ -161,40 +161,7 @@ Output all findings the author would fix if they knew about them. If there are n
 
 ## Optional Standards + Spec follow-up review
 
-Only run this pass when the user explicitly asks for a Standards + Spec review, or asks for one of those axes after the default review. Do not replace or weaken the default defect-oriented review rubric above.
-
-Keep the results separate from default review findings with these sections:
-
-```md
-## Standards Findings
-...
-
-## Spec Findings
-...
-```
-
-### Standards pass
-
-Evaluate whether the diff follows documented repository standards. Look for relevant sources such as:
-
-- `AGENTS.md` and nested agent/instruction files that apply to the changed paths
-- `CONTRIBUTING.md`, `CONTEXT.md`, README guidance, and docs that define contributor or project conventions
-- ADRs or decision records that constrain the changed area
-- Tooling/config files that express repository policy, such as linters, formatters, TypeScript config, test config, CI workflows, package scripts, or dependency policy files
-
-Do not spend findings on rules that machines already enforce unless the diff bypasses or weakens that enforcement. Flag only standards mismatches that are actionable, introduced by the diff, and likely worth fixing.
-
-For each Standards finding, cite the relevant standards source. If no relevant standards source exists, say so and keep the pass brief.
-
-### Spec pass
-
-Evaluate whether the diff matches the originating issue, PRD, ADR, design note, PR description, or user-provided spec.
-
-First identify the best available spec source from the review context, including issue/PR links, `closes #...` references, PR body references, linked PRD comments, ADR comments, or explicit user instructions. Prefer the newest linked PRD/comment that actually contains the expected structured marker when those artifacts exist. Treat ADRs and explicit decisions as constraints.
-
-If no spec source is available, clearly say that and do not invent requirements. If a spec source is stale, unreadable, or missing the expected marker, say so plainly and use the minimum direct context available.
-
-For each Spec finding, cite the spec source and explain the mismatch. Keep Spec findings separate from Standards and default review findings.
+Do not run Standards or Spec checks during the default review pass unless the user explicitly asks for them. When the user asks for a Standards review, Spec review, or Standards + Spec follow-up, load `skills/pac-review-standards-spec/SKILL.md` and keep those findings separate from default review findings.
 
 ## Fix session commit discipline
 


### PR DESCRIPTION
Document an optional Standards + Spec review pass and preserve separate review-pass findings in /review-end summaries.

Verification: npm test; npm run typecheck

closes #255
