### PR TITLE
✨ feat(git): Block fixup commits before main merges

### DIFF
--- a/.config/hk.pkl
+++ b/.config/hk.pkl
@@ -2,6 +2,22 @@ amends "package://github.com/jdx/hk/releases/download/v1.38.0/hk@1.38.0#/Config.
 import "package://github.com/jdx/hk/releases/download/v1.38.0/hk@1.38.0#/Builtins.pkl"
 
 hooks {
+    ["pre-push"] {
+        steps {
+            ["prevent-fixup-merge"] {
+                check = "scripts/prevent-fixup-merge.sh pre-push"
+            }
+        }
+    }
+
+    ["pre-merge-commit"] {
+        steps {
+            ["prevent-fixup-merge"] {
+                check = "scripts/prevent-fixup-merge.sh"
+            }
+        }
+    }
+
     ["pre-commit"] {
         fix = true
         stash = "git"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioned sections should match the Git tags and GitHub releases published for t
 
 ### Added
 
+- Added hooks that block `fixup!` commits from being merged or pushed into `main` through the local workflow. ([#259](https://github.com/ladislas/mypac/issues/259))
 - Added optional Standards + Spec follow-up review support with a dedicated `pac-review-standards-spec` skill and `/review-end` summaries that preserve default, standards, and spec findings separately. ([#255](https://github.com/ladislas/mypac/issues/255))
 - Added `/pac-fix-copilot-review` for addressing GitHub Copilot PR review comments with explicit fixup commits and resolved review threads. ([#246](https://github.com/ladislas/mypac/issues/246))
 - Added a `notify` Pi extension that sends terminal notifications with the latest assistant response summary when Pi is ready for input, using terminal-specific OSC sequences with OSC 777 as the fallback. ([#236](https://github.com/ladislas/mypac/issues/236))

--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ Saved-deck replies include a clickable Markdown `file://` link, and the shared d
 - Run the checks on demand: `mise run lint`
 - Auto-fix Markdown lint issues: `mise run lint:fix`
 
-The hk configuration lints YAML and Markdown files before commit.
-If a check fails, fix the reported file and run the hook again or retry the commit.
+The hk configuration lints YAML and Markdown files before commit. It also blocks merges and pushes to `main` when the incoming commits include subjects that start with `fixup!`.
+If a check fails, fix the reported file and run the hook again or retry the commit. For a `fixup!` merge or push failure, squash the fixup commits first, for example with `git rebase --autosquash main`, then retry.
 
 ### Changelog
 

--- a/scripts/prevent-fixup-merge.sh
+++ b/scripts/prevent-fixup-merge.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env sh
+set -eu
+
+zero_oid="0000000000000000000000000000000000000000"
+
+offending_commits_for_range() {
+	range=$1
+	log_output=$(git log --format='%H %s' "$range" -- 2>&1) || {
+		printf 'Unable to inspect commits for range %s:\n%s\n' "$range" "$log_output" >&2
+		exit 1
+	}
+
+	printf '%s\n' "$log_output" | grep '^[0-9a-f][0-9a-f]* fixup!' || true
+}
+
+check_pre_push() {
+	offending_commits=""
+	while read -r local_ref local_oid remote_ref remote_oid; do
+		[ -n "${local_ref:-}" ] || continue
+		[ "$remote_ref" = "refs/heads/main" ] || continue
+		[ "$local_oid" != "$zero_oid" ] || continue
+
+		if [ "$remote_oid" = "$zero_oid" ]; then
+			range="$local_oid"
+		else
+			range="$remote_oid..$local_oid"
+		fi
+
+		commits=$(offending_commits_for_range "$range")
+		if [ -n "$commits" ]; then
+			offending_commits=${offending_commits}${commits}'
+'
+		fi
+	done
+
+	if [ -z "$offending_commits" ]; then
+		exit 0
+	fi
+
+	cat >&2 <<EOF
+Refusing to push fixup! commits to main.
+
+Squash these commits before pushing, for example with:
+  git rebase --autosquash main
+
+Offending commits:
+$offending_commits
+EOF
+
+	exit 1
+}
+
+check_pre_merge_commit() {
+	current_branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+	if [ "$current_branch" != "main" ]; then
+		exit 0
+	fi
+
+	if [ ! -f "$(git rev-parse --git-path MERGE_HEAD)" ]; then
+		exit 0
+	fi
+
+	offending_commits=""
+	while IFS= read -r merge_head; do
+		[ -n "$merge_head" ] || continue
+		commits=$(offending_commits_for_range HEAD.."$merge_head")
+		if [ -n "$commits" ]; then
+			offending_commits=${offending_commits}${commits}'
+'
+		fi
+	done < "$(git rev-parse --git-path MERGE_HEAD)"
+
+	if [ -z "$offending_commits" ]; then
+		exit 0
+	fi
+
+	cat >&2 <<EOF
+Refusing to merge fixup! commits into main.
+
+Squash these commits before merging, for example with:
+  git rebase --autosquash main
+
+Offending commits:
+$offending_commits
+EOF
+
+	exit 1
+}
+
+case "${1:-pre-merge-commit}" in
+	pre-push)
+		check_pre_push
+		;;
+	pre-merge-commit)
+		check_pre_merge_commit
+		;;
+	*)
+		echo "Usage: $0 [pre-merge-commit|pre-push]" >&2
+		exit 2
+		;;
+esac

--- a/scripts/prevent-fixup-merge.test.mjs
+++ b/scripts/prevent-fixup-merge.test.mjs
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { appendFileSync, cpSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const scriptSource = join(testDir, "prevent-fixup-merge.sh");
+
+function run(command, args, options = {}) {
+	const { allowFailure, ...spawnOptions } = options;
+	const result = spawnSync(command, args, {
+		encoding: "utf8",
+		...spawnOptions,
+	});
+
+	if (allowFailure !== true && result.status !== 0) {
+		throw new Error([
+			`Command failed: ${command} ${args.join(" ")}`,
+			`status: ${result.status}`,
+			`stdout: ${result.stdout}`,
+			`stderr: ${result.stderr}`,
+		].join("\n"));
+	}
+
+	return result;
+}
+
+function createRepo(t) {
+	const dir = mkdtempSync(join(tmpdir(), "prevent-fixup-merge-"));
+	t.after(() => rmSync(dir, { recursive: true, force: true }));
+	cpSync(scriptSource, join(dir, "prevent-fixup-merge.sh"));
+	run("git", ["init", "--initial-branch=main"], { cwd: dir });
+	run("git", ["config", "user.name", "Test User"], { cwd: dir });
+	run("git", ["config", "user.email", "test@example.com"], { cwd: dir });
+	writeFileSync(join(dir, "file.txt"), "base\n");
+	run("git", ["add", "file.txt"], { cwd: dir });
+	run("git", ["commit", "-m", "base"], { cwd: dir });
+	return dir;
+}
+
+function commitOnBranch(repo, branch, subject) {
+	run("git", ["switch", "-c", branch], { cwd: repo });
+	appendFileSync(join(repo, "file.txt"), `${subject}\n`);
+	run("git", ["add", "file.txt"], { cwd: repo });
+	run("git", ["commit", "-m", subject], { cwd: repo });
+	run("git", ["switch", "main"], { cwd: repo });
+}
+
+function startMerge(repo, branch) {
+	run("git", ["merge", "--no-ff", "--no-commit", branch], { cwd: repo });
+}
+
+function revParse(repo, ref) {
+	return run("git", ["rev-parse", ref], { cwd: repo }).stdout.trim();
+}
+
+function prePushInput(localOid, remoteOid = "0000000000000000000000000000000000000000") {
+	return `refs/heads/main ${localOid} refs/heads/main ${remoteOid}\n`;
+}
+
+test("allows a merge whose incoming commits do not start with fixup!", (t) => {
+	const repo = createRepo(t);
+	commitOnBranch(repo, "feature", "normal change");
+	startMerge(repo, "feature");
+
+	const result = run("sh", ["prevent-fixup-merge.sh"], { cwd: repo });
+
+	assert.equal(result.status, 0);
+	assert.equal(result.stderr, "");
+});
+
+test("blocks a merge whose incoming commits include a fixup! subject", (t) => {
+	const repo = createRepo(t);
+	commitOnBranch(repo, "feature", "fixup! normal change");
+	startMerge(repo, "feature");
+
+	const result = run("sh", ["prevent-fixup-merge.sh"], { cwd: repo, allowFailure: true });
+
+	assert.equal(result.status, 1);
+	assert.match(result.stderr, /Refusing to merge fixup! commits into main/);
+	assert.match(result.stderr, /fixup! normal change/);
+});
+
+test("does not block fixup! commits when the current branch is not main", (t) => {
+	const repo = createRepo(t);
+	commitOnBranch(repo, "topic", "fixup! normal change");
+	run("git", ["switch", "-c", "integration"], { cwd: repo });
+	startMerge(repo, "topic");
+
+	const result = run("sh", ["prevent-fixup-merge.sh"], { cwd: repo });
+
+	assert.equal(result.status, 0);
+	assert.equal(result.stderr, "");
+});
+
+test("allows a push to main whose new commits do not start with fixup!", (t) => {
+	const repo = createRepo(t);
+	const remoteOid = revParse(repo, "main");
+	commitOnBranch(repo, "feature", "normal change");
+	const localOid = revParse(repo, "feature");
+
+	const result = run("sh", ["prevent-fixup-merge.sh", "pre-push"], {
+		cwd: repo,
+		input: prePushInput(localOid, remoteOid),
+	});
+
+	assert.equal(result.status, 0);
+	assert.equal(result.stderr, "");
+});
+
+test("blocks a push to main whose new commits include a fixup! subject", (t) => {
+	const repo = createRepo(t);
+	const remoteOid = revParse(repo, "main");
+	commitOnBranch(repo, "feature", "fixup! normal change");
+	const localOid = revParse(repo, "feature");
+
+	const result = run("sh", ["prevent-fixup-merge.sh", "pre-push"], {
+		cwd: repo,
+		input: prePushInput(localOid, remoteOid),
+		allowFailure: true,
+	});
+
+	assert.equal(result.status, 1);
+	assert.match(result.stderr, /Refusing to push fixup! commits to main/);
+	assert.match(result.stderr, /fixup! normal change/);
+});
+
+test("fails closed when the pushed main range cannot be inspected", (t) => {
+	const repo = createRepo(t);
+	const missingOid = "1111111111111111111111111111111111111111";
+	const localOid = revParse(repo, "main");
+
+	const result = run("sh", ["prevent-fixup-merge.sh", "pre-push"], {
+		cwd: repo,
+		input: prePushInput(localOid, missingOid),
+		allowFailure: true,
+	});
+
+	assert.equal(result.status, 1);
+	assert.match(result.stderr, /Unable to inspect commits for range/);
+});


### PR DESCRIPTION
Add a pre-merge hk check that rejects incoming commits whose subjects start with fixup! when merging into main, plus regression coverage and documentation for autosquash resolution.

Verification: npm test; npm run typecheck; mise run lint; hk validate; hk run pre-merge-commit

closes #259
