### PR TITLE
✨ feat(skills): Add pac handoff skill

### DIFF
--- a/.pac/upstream-sources.yaml
+++ b/.pac/upstream-sources.yaml
@@ -790,6 +790,37 @@ local_artifacts:
     known_divergence:
       - mypac grill-me is pac-prefixed and keeps questioning bounded by local planning conventions.
 
+  - id: pi-skill-handoff
+    title: Handoff skill
+    kind: skill
+    local:
+      paths:
+        - skills/pac-handoff/
+    upstream_refs:
+      - id: mattpocock-handoff-skill
+        role: pattern_source
+        status: active
+        sync_policy: targeted
+        repo: https://github.com/mattpocock/skills
+        ref: main
+        paths:
+          - skills/productivity/handoff/SKILL.md
+        attribution:
+          upstream: mattpocock/skills/skills/productivity/handoff/SKILL.md
+          license: Review upstream repository before copying new text or structure.
+          notes: Local guidance adapts upstream handoff constraints to Pi session transitions and pac artifact conventions.
+        last_reviewed:
+          upstream_commit: e74f0061bb67222181640effa98c675bdb2fdaa7
+          checkpoint_issue: https://github.com/ladislas/mypac/issues/261
+          reviewed_at: 2026-05-21T00:00:00Z
+          notes: "Adopted as a compact pac-prefixed handoff skill after issue #261 investigation."
+    attribution:
+      upstream: mattpocock/skills
+      license: Review upstream repository before copying new text or structure.
+      notes: Local guidance adapts upstream handoff constraints to Pi session transitions and pac artifact conventions.
+    known_divergence:
+      - mypac handoff guidance is pac-prefixed and emphasizes Pi sessions plus GitHub-native durable artifacts.
+
   - id: pi-skill-authoring
     title: Pi skill authoring skill
     kind: skill

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ For readability, the skill table below drops the `pac-` prefix in the display la
 | [`github-issue-create`](skills/pac-github-issue-create/SKILL.md) | Create well-formed GitHub issues from inside the current repository |
 | [`grill-me`](skills/pac-grill-me/SKILL.md) | Relentlessly interview a plan or design one question at a time until it is clear |
 | [`grill-with-docs`](skills/pac-grill-with-docs/SKILL.md) | Grill issue-backed work, then persist durable outcomes to GitHub issue comments and sparing local context |
+| [`handoff`](skills/pac-handoff/SKILL.md) | Create a concise handoff document for another Pi session or agent |
 | [`improve-architecture`](skills/pac-improve-architecture/SKILL.md) | Review a codebase for deepening opportunities, then grill a chosen architecture candidate |
 | [`librarian`](skills/pac-librarian/SKILL.md) | Cache and refresh remote git repositories locally for future reference work |
 | [`explore`](skills/pac-explore/SKILL.md) | Explore ideas, investigate problems, and compare options without implementing |

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ For readability, the skill table below drops the `pac-` prefix in the display la
 | [`/pac-diagnose`](prompts/pac-diagnose.md) | Diagnose a bug or performance regression with a disciplined feedback-loop workflow |
 | [`/pac-grill-me`](prompts/pac-grill-me.md) | Relentlessly interview a plan or design one question at a time until it is clear |
 | [`/pac-grill-with-docs`](prompts/pac-grill-with-docs.md) | Grill issue-backed work and persist durable outcomes to GitHub issue notes and sparing local context |
+| [`/pac-handoff`](prompts/pac-handoff.md) | Create a concise handoff document for another Pi session or agent |
 | [`/pac-to-issues`](prompts/pac-to-issues.md) | Break a plan, PRD, or discussion into tracer-bullet GitHub issues |
 | [`/pac-to-prd`](prompts/pac-to-prd.md) | Synthesize context into a draft PRD or publishable GitHub PRD artifact |
 | [`/pac-triage`](prompts/pac-triage.md) | Triage GitHub issues through mypac's label-based issue workflow |

--- a/prompts/pac-handoff.md
+++ b/prompts/pac-handoff.md
@@ -1,0 +1,12 @@
+---
+description: "Create a concise handoff document for another Pi session or agent"
+argument-hint: "[next-session focus]"
+---
+
+Create a concise handoff document for another Pi session or agent.
+
+Read and follow `skills/pac-handoff/SKILL.md`.
+
+Use the optional argument after `/pac-handoff` as the next-session focus. If no argument is provided, infer the focus from the current conversation and ask only if unclear.
+
+**Provided arguments**: $@

--- a/skills/pac-handoff/SKILL.md
+++ b/skills/pac-handoff/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: pac-handoff
+description: "Creates a concise handoff document for another Pi session or agent. Use when ending work, switching sessions, pausing multi-step work, or preparing context for a fresh agent."
+license: MIT
+compatibility: Pi coding agent
+metadata:
+  author: mypac
+  stage: shared
+---
+
+# Create a handoff for the next session
+
+Use this skill when the current work should be easy for a fresh Pi session or another agent to continue.
+
+## Process
+
+1. Identify the intended next-session focus.
+   - If the user provided a focus, tailor the handoff to it.
+   - If the focus is unclear, ask one concise clarifying question.
+2. Create a durable handoff file outside the current workspace under `~/.pi/agent/handoffs/<timestamp>-<slug>.md`.
+   - Use a UTC timestamp such as `YYYYMMDD-HHMMSS`.
+   - Derive `<slug>` from the handoff title or next-session focus.
+3. Invoke the `read` tool on the new file so its path appears visibly in the transcript.
+4. Write a concise handoff document to that path.
+5. Return the path and a short summary to the user.
+
+## Handoff content
+
+Include only what the next session needs:
+
+- Goal or next-session focus
+- Current status
+- Key decisions already made
+- Durable artifacts to read next
+- Suggested skills or prompts to load
+- Immediate next actions
+- Open questions or risks
+
+Do **not** duplicate content already captured in durable artifacts. Reference issues, PRDs, ADRs, comments, commits, diffs, todos, or file paths instead of re-summarizing them in full.
+
+## Suggested format
+
+```md
+# Handoff: <short title>
+
+## Focus
+<what the next session should do>
+
+## Status
+<where things stand>
+
+## Durable artifacts
+- <issue/PR/comment/path/commit/diff reference>
+
+## Suggested skills/prompts
+- <skill or prompt, if useful>
+
+## Next actions
+1. <first action>
+2. <second action>
+
+## Open questions / risks
+- <question or risk, if any>
+```
+
+Keep the document compact. Prefer pointers over prose when a durable artifact already contains the detail.

--- a/skills/pac-to-prd/SKILL.md
+++ b/skills/pac-to-prd/SKILL.md
@@ -78,10 +78,10 @@ Default to `draft-only` unless the user clearly asks for GitHub publication.
 Write a local draft outside the repo under:
 
 ```text
-~/.pi/agent/prds/<session-id>/<timestamp>-<slug>.md
+~/.pi/agent/prds/<timestamp>-<slug>.md
 ```
 
-Derive `<session-id>` from the current Pi session identifier, following the same convention used by the slidedeck extension (`extensions/slidedeck/`). `<timestamp>` is `YYYYMMDDHHmmss` in UTC. `<slug>` is a lowercase, hyphen-separated summary of the PRD title (e.g. `pac-to-prd-draft-workflow`).
+Use a UTC timestamp such as `YYYYMMDD-HHMMSS`. Derive `<slug>` from the PRD title as a lowercase, hyphen-separated summary (e.g. `pac-to-prd-draft-workflow`).
 
 Store minimal human-editable metadata as YAML frontmatter:
 


### PR DESCRIPTION
Adopt Matt Pocock's handoff pattern as a compact pac-prefixed skill for Pi session transitions, with upstream provenance registered.

Verification: node --experimental-strip-types --test

Verification: npm run typecheck

closes #261
