### PR TITLE
🐛 fix(librarian): Preserve unshallowed checkout refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Versioned sections should match the Git tags and GitHub releases published for t
 ### Changed
 
 - Taught implementation-oriented prompts to load `pac-tdd` selectively for behavior-changing work, bug fixes, and regression coverage. ([#210](https://github.com/ladislas/mypac/issues/210))
+- Preserved full-history `pac-librarian` checkouts during refreshes so upstream checkpoint range reviews are not re-shallowed after unshallowing. ([#232](https://github.com/ladislas/mypac/issues/232))
 - Taught `/ghi` issue creation to infer existing pac workflow state labels and warn users to run `/pac-setup-workflows` when expected labels are missing. ([#202](https://github.com/ladislas/mypac/issues/202))
 - Aligned label-dependent workflows on canonical `pac:*` labels and `/pac-setup-workflows` warnings instead of legacy label fallbacks. ([#199](https://github.com/ladislas/mypac/issues/199))
 - Added one-off optional custom instruction prompts to `/review-start` selector runs and `/review-end` summarize/fix flows, with Enter-to-skip and Esc-to-cancel behavior while keeping `--extra` and shared review instructions unchanged. ([#115](https://github.com/ladislas/mypac/issues/115))

--- a/skills/pac-librarian/SKILL.md
+++ b/skills/pac-librarian/SKILL.md
@@ -55,6 +55,7 @@ The script will:
 ## Update strategy
 
 - Default behavior is **throttled refresh** (every 5 minutes) to avoid unnecessary network calls.
+- Refreshes preserve the checkout's current history depth: shallow checkouts stay shallow, but checkouts that another workflow has unshallowed are fetched without `--depth=1`.
 - Force immediate refresh with:
 
 ```bash

--- a/skills/pac-librarian/checkout.sh
+++ b/skills/pac-librarian/checkout.sh
@@ -230,7 +230,15 @@ update_state="skipped"
 ff_state="not-attempted"
 
 if (( needs_update == 1 )); then
-  git -C "$checkout_path" fetch --depth=1 --prune --tags origin >/dev/null
+  is_shallow="$(git -C "$checkout_path" rev-parse --is-shallow-repository 2>/dev/null || true)"
+  if [[ -z "$is_shallow" && -f "$checkout_path/.git/shallow" ]]; then
+    is_shallow="true"
+  fi
+  if [[ "$is_shallow" == "true" ]]; then
+    git -C "$checkout_path" fetch --depth=1 --prune --tags origin >/dev/null
+  else
+    git -C "$checkout_path" fetch --prune --tags origin >/dev/null
+  fi
   echo "$now_epoch" > "$last_fetch_file"
   update_state="fetched"
 

--- a/skills/pac-librarian/checkout.test.mjs
+++ b/skills/pac-librarian/checkout.test.mjs
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const skillDir = dirname(fileURLToPath(import.meta.url));
+const checkoutScript = join(skillDir, "checkout.sh");
+
+function run(command, args, options = {}) {
+	const { allowFailure, ...spawnOptions } = options;
+	const result = spawnSync(command, args, {
+		encoding: "utf8",
+		...spawnOptions,
+	});
+
+	if (allowFailure !== true && result.status !== 0) {
+		throw new Error([
+			`Command failed: ${command} ${args.join(" ")}`,
+			`status: ${result.status}`,
+			`stdout: ${result.stdout}`,
+			`stderr: ${result.stderr}`,
+		].join("\n"));
+	}
+
+	return result;
+}
+
+function setupFakeGit(t, options) {
+	const { isShallow, failShallowDetection = false, hasShallowFile = false } = options;
+	const dir = mkdtempSync(join(tmpdir(), "pac-librarian-test-"));
+	t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+	const bin = join(dir, "bin");
+	const cacheRoot = join(dir, "cache");
+	const checkoutPath = join(cacheRoot, "github.com", "owner", "repo");
+	const gitDir = join(checkoutPath, ".git");
+	const logPath = join(dir, "git.log");
+
+	mkdirSync(bin, { recursive: true });
+	mkdirSync(gitDir, { recursive: true });
+	writeFileSync(join(gitDir, "fake-origin"), "https://github.com/owner/repo.git");
+	writeFileSync(join(gitDir, "fake-is-shallow"), `${isShallow}\n`);
+	writeFileSync(join(gitDir, "fake-fail-shallow-detection"), `${failShallowDetection}\n`);
+	if (hasShallowFile) writeFileSync(join(gitDir, "shallow"), "fake-shallow-boundary\n");
+
+	writeFileSync(join(bin, "git"), String.raw`#!/usr/bin/env bash
+set -euo pipefail
+log=__LOG_PATH__
+printf '%s\n' "$*" >> "$log"
+workdir=""
+if [[ "$1" == "-C" ]]; then
+  workdir="$2"
+  shift 2
+fi
+cmd="$1"
+shift || true
+case "$cmd" in
+  clone)
+    checkout_path="$1"
+    for arg in "$@"; do checkout_path="$arg"; done
+    mkdir -p "$checkout_path/.git"
+    printf '%s\n' "https://github.com/owner/repo.git" > "$checkout_path/.git/fake-origin"
+    printf '%s\n' true > "$checkout_path/.git/fake-is-shallow"
+    ;;
+  remote)
+    subcmd="$1"; shift
+    case "$subcmd" in
+      get-url)
+        if [[ -f "$workdir/.git/fake-origin" ]]; then cat "$workdir/.git/fake-origin"; else exit 1; fi
+        ;;
+      add|set-url)
+        printf '%s\n' "$2" > "$workdir/.git/fake-origin"
+        ;;
+    esac
+    ;;
+  fetch)
+    ;;
+  symbolic-ref)
+    printf '%s\n' main
+    ;;
+  rev-parse)
+    if [[ "$*" == "--is-shallow-repository" ]]; then
+      if [[ "$(cat "$workdir/.git/fake-fail-shallow-detection")" == "true" ]]; then exit 1; fi
+      cat "$workdir/.git/fake-is-shallow"
+    elif [[ "$*" == "--abbrev-ref --symbolic-full-name @{u}" ]]; then
+      printf '%s\n' origin/main
+    else
+      printf '%s\n' fake-ref
+    fi
+    ;;
+  status)
+    ;;
+  merge)
+    ;;
+  *)
+    echo "unexpected git command: $cmd $*" >&2
+    exit 99
+    ;;
+esac
+`.replace("__LOG_PATH__", JSON.stringify(logPath)), { mode: 0o755 });
+
+	return { dir, bin, cacheRoot, logPath };
+}
+
+function runCheckoutWithFakeGit(t, options) {
+	const fixture = setupFakeGit(t, options);
+	const result = run("bash", [checkoutScript, "owner/repo", "--force-update", "--path-only"], {
+		env: {
+			...process.env,
+			PATH: `${fixture.bin}:${process.env.PATH}`,
+			LIBRARIAN_CACHE_ROOT: fixture.cacheRoot,
+		},
+	});
+
+	return { ...fixture, result };
+}
+
+test("force update preserves full-history checkouts", (t) => {
+	const { logPath, result } = runCheckoutWithFakeGit(t, { isShallow: false });
+
+	assert.equal(result.status, 0);
+	const log = run("cat", [logPath]).stdout;
+	assert.match(log, /fetch --prune --tags origin/);
+	assert.doesNotMatch(log, /fetch --depth=1 --prune --tags origin/);
+});
+
+test("force update keeps shallow fetches shallow", (t) => {
+	const { logPath, result } = runCheckoutWithFakeGit(t, { isShallow: true });
+
+	assert.equal(result.status, 0);
+	const log = run("cat", [logPath]).stdout;
+	assert.match(log, /fetch --depth=1 --prune --tags origin/);
+});
+
+test("force update treats unknown shallow state without shallow file as full history", (t) => {
+	const { logPath, result } = runCheckoutWithFakeGit(t, { isShallow: false, failShallowDetection: true });
+
+	assert.equal(result.status, 0);
+	const log = run("cat", [logPath]).stdout;
+	assert.match(log, /fetch --prune --tags origin/);
+	assert.doesNotMatch(log, /fetch --depth=1 --prune --tags origin/);
+});
+
+test("force update falls back to shallow file when shallow detection is unavailable", (t) => {
+	const { logPath, result } = runCheckoutWithFakeGit(t, {
+		isShallow: false,
+		failShallowDetection: true,
+		hasShallowFile: true,
+	});
+
+	assert.equal(result.status, 0);
+	const log = run("cat", [logPath]).stdout;
+	assert.match(log, /fetch --depth=1 --prune --tags origin/);
+});


### PR DESCRIPTION
Keep pac-librarian updates shallow only for checkouts that are still shallow, so upstream checkpoint workflows that unshallow a cached repository can keep doing range-based history review.

Verification: npm test; npm run typecheck; representative mitsuhiko/agent-stuff checkout stayed unshallowed after force update.

closes #232
