### PR TITLE
✨ feat(footer): Add custom token budget footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioned sections should match the Git tags and GitHub releases published for t
 
 ### Added
 
+- Added a custom Pi footer extension with write-cache token totals, provider-qualified model labels, context/budget threshold coloring, Codex/Copilot/Claude usage bars, and no default auto-compaction percentage segment. ([#265](https://github.com/ladislas/mypac/issues/265))
 - Added hooks that block `fixup!` commits from being merged or pushed into `main` through the local workflow. ([#259](https://github.com/ladislas/mypac/issues/259))
 - Added optional Standards + Spec follow-up review support with a dedicated `pac-review-standards-spec` skill and `/review-end` summaries that preserve default, standards, and spec findings separately. ([#255](https://github.com/ladislas/mypac/issues/255))
 - Added `/pac-fix-copilot-review` for addressing GitHub Copilot PR review comments with explicit fixup commits and resolved review threads. ([#246](https://github.com/ladislas/mypac/issues/246))

--- a/extensions/footer/helpers.test.mjs
+++ b/extensions/footer/helpers.test.mjs
@@ -1,0 +1,71 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+	formatLocationLine,
+	formatModelName,
+	formatSessionLine,
+	formatStatusSegment,
+	getBudgetColor,
+	getContextColor,
+	sumUsageFromEntries,
+} from "./helpers.ts";
+
+test("formatStatusSegment keeps compact token/cache/cost shape", () => {
+	assert.equal(
+		formatStatusSegment(
+			{ input: 183_000, output: 12_000, cacheRead: 682_000, cacheWrite: 3_400, totalCost: 1.621 },
+			true,
+		),
+		"↑183k ↓12k R682k W3.4k $1.621 (sub)",
+	);
+});
+
+test("formatStatusSegment omits write cache when zero", () => {
+	assert.equal(
+		formatStatusSegment(
+			{ input: 216_000, output: 12_000, cacheRead: 3_300_000, cacheWrite: 0, totalCost: 3.094 },
+			true,
+		),
+		"↑216k ↓12k R3.3M $3.094 (sub)",
+	);
+});
+
+test("sumUsageFromEntries totals assistant usage", () => {
+	const totals = sumUsageFromEntries([
+		{ type: "message", message: { role: "user" } },
+		{ type: "message", message: { role: "assistant", usage: { input: 100, output: 20, cacheRead: 30, cacheWrite: 40, cost: { total: 0.2 } } } },
+		{ type: "message", message: { role: "assistant", usage: { input: 200, output: 30, cacheRead: 50, cacheWrite: 60, cost: { total: 0.3 } } } },
+	]);
+
+	assert.deepEqual(totals, { input: 300, output: 50, cacheRead: 80, cacheWrite: 100, totalCost: 0.5 });
+});
+
+test("formatModelName includes provider when available", () => {
+	assert.equal(formatModelName({ provider: "openai-codex", id: "gpt-5.5", reasoning: true }, "medium"), "openai-codex/gpt-5.5");
+});
+
+test("formatLocationLine separates cwd and branch without parentheses", () => {
+	const home = process.env.HOME || process.env.USERPROFILE;
+	assert.ok(home);
+	assert.equal(
+		formatLocationLine({ cwd: `${home}/dev/ladislas/mypac`, branch: "ladislas/feature/footer_token-budget-indicators" }),
+		"~/dev/ladislas/mypac · ladislas/feature/footer_token-budget-indicators",
+	);
+});
+
+test("formatSessionLine keeps short session id and simplified issue name", () => {
+	assert.equal(formatSessionLine({ sessionId: "abc123456789", sessionName: "lwot - issue #265" }), "session abc12345 · lwot #265");
+});
+
+test("usage budget color gets more urgent as remaining budget falls", () => {
+	assert.equal(getBudgetColor(100), "success");
+	assert.equal(getBudgetColor(41), "success");
+	assert.equal(getBudgetColor(40), "warning");
+	assert.equal(getBudgetColor(20), "error");
+});
+
+test("context color warns before and turns red at the fixed 120k dumb zone", () => {
+	assert.equal(getContextColor(71_999), "success");
+	assert.equal(getContextColor(72_000), "warning");
+	assert.equal(getContextColor(120_000), "error");
+});

--- a/extensions/footer/helpers.ts
+++ b/extensions/footer/helpers.ts
@@ -1,0 +1,258 @@
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+
+export interface FooterUsageTotals {
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+	totalCost: number;
+}
+
+export interface FooterModelRef {
+	provider?: string;
+	id?: string;
+	reasoning?: boolean;
+	contextWindow?: number;
+}
+
+export interface FooterContextUsage {
+	tokens: number | null;
+	contextWindow: number;
+}
+
+export interface FooterRenderData {
+	cwd?: string;
+	branch?: string | null;
+	sessionId?: string;
+	sessionName?: string;
+	usage: FooterUsageTotals;
+	usingSubscription: boolean;
+	model?: FooterModelRef;
+	thinkingLevel?: string;
+	contextUsage?: FooterContextUsage;
+	providerUsage?: FooterProviderUsage | null;
+}
+
+export interface FooterUsageWindow {
+	label: string;
+	usedPercent: number;
+	resetsIn?: string;
+}
+
+export interface FooterProviderUsage {
+	provider: string;
+	windows: FooterUsageWindow[];
+}
+
+const BAR_FILLED = "━";
+const BAR_EMPTY = "─";
+
+export function formatTokens(count: number): string {
+	if (count < 1000) return Math.round(count).toString();
+	if (count < 10000) return `${(count / 1000).toFixed(1)}k`;
+	if (count < 1000000) return `${Math.round(count / 1000)}k`;
+	if (count < 10000000) return `${(count / 1000000).toFixed(1)}M`;
+	return `${Math.round(count / 1000000)}M`;
+}
+
+export function sumUsageFromEntries(entries: readonly unknown[]): FooterUsageTotals {
+	const totals: FooterUsageTotals = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalCost: 0 };
+	for (const entry of entries as any[]) {
+		if (entry?.type !== "message" || entry.message?.role !== "assistant") continue;
+		const usage = entry.message.usage;
+		if (!usage) continue;
+		totals.input += Number(usage.input ?? 0) || 0;
+		totals.output += Number(usage.output ?? 0) || 0;
+		totals.cacheRead += Number(usage.cacheRead ?? 0) || 0;
+		totals.cacheWrite += Number(usage.cacheWrite ?? 0) || 0;
+		totals.totalCost += Number(usage.cost?.total ?? usage.cost ?? 0) || 0;
+	}
+	return totals;
+}
+
+export function formatStatusSegment(usage: FooterUsageTotals, usingSubscription: boolean): string {
+	const parts: string[] = [];
+	if (usage.input) parts.push(`↑${formatTokens(usage.input)}`);
+	if (usage.output) parts.push(`↓${formatTokens(usage.output)}`);
+	if (usage.cacheRead) parts.push(`R${formatTokens(usage.cacheRead)}`);
+	if (usage.cacheWrite) parts.push(`W${formatTokens(usage.cacheWrite)}`);
+	if (usage.totalCost || usingSubscription) {
+		parts.push(`$${usage.totalCost.toFixed(3)}${usingSubscription ? " (sub)" : ""}`);
+	}
+	return parts.join(" ");
+}
+
+export function getBudgetColor(remainingPercent: number): "success" | "warning" | "error" {
+	if (remainingPercent <= 20) return "error";
+	if (remainingPercent <= 40) return "warning";
+	return "success";
+}
+
+export function getContextColor(tokens: number): "success" | "warning" | "error" {
+	if (tokens >= 120_000) return "error";
+	if (tokens >= 72_000) return "warning";
+	return "success";
+}
+
+export function formatModelName(model?: FooterModelRef, _thinkingLevel?: string): string {
+	if (!model?.id) return "no-model";
+	const provider = model.provider ? `${model.provider}/` : "";
+	return `${provider}${model.id}`;
+}
+
+export function formatLocationLine(data: Pick<FooterRenderData, "cwd" | "branch" | "sessionId" | "sessionName">): string {
+	if (data.cwd) {
+		let cwd = data.cwd;
+		const home = process.env.HOME || process.env.USERPROFILE;
+		if (home && cwd.startsWith(home)) cwd = `~${cwd.slice(home.length)}`;
+		return data.branch ? `${cwd} · ${data.branch}` : cwd;
+	}
+	return "";
+}
+
+export function formatSessionLine(data: Pick<FooterRenderData, "sessionId" | "sessionName">): string {
+	const meta = formatSessionMeta(data);
+	return meta ? `session ${meta}` : "session";
+}
+
+function formatSessionMeta(data: Pick<FooterRenderData, "sessionId" | "sessionName">): string {
+	const parts: string[] = [];
+	if (data.sessionId) parts.push(data.sessionId.slice(0, 8));
+	if (data.sessionName) parts.push(formatSessionName(data.sessionName));
+	return parts.join(" · ");
+}
+
+function formatSessionName(name: string): string {
+	return name.replace(/\s*-\s*issue\s+#(\d+)\b/i, " #$1").replace(/\bissue\s+#(\d+)\b/i, "#$1").replace(/\s+/g, " ").trim();
+}
+
+function renderTokenBar(tokens: number, contextWindow: number, theme: any): string {
+	const width = 12;
+	const percent = contextWindow > 0 ? Math.max(0, Math.min(100, (tokens / contextWindow) * 100)) : 0;
+	const filled = Math.round((percent / 100) * width);
+	const color = getContextColor(tokens);
+	const bar = theme.fg(color, BAR_FILLED.repeat(filled)) + theme.fg("dim", BAR_EMPTY.repeat(width - filled));
+	return `${theme.fg("dim", "ctx ")}${bar} ${theme.fg("dim", `${formatTokens(tokens)}/${formatTokens(contextWindow)}`)}`;
+}
+
+export function renderFooterLines(data: FooterRenderData, width: number, theme: any): string[] {
+	const safeWidth = Math.max(1, width);
+	const location = formatLocationLine(data);
+	const sessionMeta = formatSessionMeta(data);
+	const modelLine = buildModelSegments(data, theme).join(theme.fg("dim", " · "));
+	const contextSegment = buildContextSegment(data, theme);
+	const status = theme.fg("dim", formatStatusSegment(data.usage, data.usingSubscription));
+	const contextPercent = buildContextPercentSegment(data, theme);
+	const statusWithPercent = [status, contextPercent].filter((segment): segment is string => Boolean(segment)).join(" ");
+	const budgetLine = [statusWithPercent, contextSegment].filter((segment): segment is string => Boolean(segment)).join(theme.fg("dim", " · "));
+	const usageParts = data.providerUsage?.windows.length ? buildUsageParts(data.providerUsage, theme) : null;
+
+	const wideLines = renderWideLines({ location, sessionMeta, modelLine, budgetLine, usageParts }, safeWidth, theme);
+	if (wideLines) return wideLines;
+
+	return renderNarrowLines({ location, sessionMeta, modelLine, budgetLine, usageParts }, safeWidth, theme);
+}
+
+function buildModelSegments(data: FooterRenderData, theme: any): string[] {
+	const model = theme.fg("dim", formatModelName(data.model, data.thinkingLevel));
+	const segments = [model];
+	if (data.model?.reasoning && data.thinkingLevel && data.thinkingLevel !== "off") {
+		segments.push(theme.fg("accent", data.thinkingLevel));
+	}
+	return segments;
+}
+
+function buildContextSegment(data: FooterRenderData, theme: any): string | null {
+	const tokens = data.contextUsage?.tokens;
+	const contextWindow = data.contextUsage?.contextWindow ?? data.model?.contextWindow ?? 0;
+	if (tokens !== null && tokens !== undefined && contextWindow > 0) {
+		return renderTokenBar(tokens, contextWindow, theme);
+	}
+	return null;
+}
+
+function buildContextPercentSegment(data: FooterRenderData, theme: any): string | null {
+	const tokens = data.contextUsage?.tokens;
+	const contextWindow = data.contextUsage?.contextWindow ?? data.model?.contextWindow ?? 0;
+	if (tokens === null || tokens === undefined || contextWindow <= 0) return null;
+	const percent = ((tokens / contextWindow) * 100).toFixed(1);
+	return theme.fg("dim", `${percent}%/${formatTokens(contextWindow)}`);
+}
+
+interface RenderParts {
+	location: string;
+	sessionMeta: string;
+	modelLine: string;
+	budgetLine: string;
+	usageParts: { left: string; windows: string[] } | null;
+}
+
+function renderWideLines(parts: RenderParts, width: number, theme: any): string[] | null {
+	const lines: string[] = [];
+	const first = joinColumns(theme.fg("dim", parts.location), theme.fg("dim", parts.sessionMeta), width);
+	if (!first) return null;
+	if (parts.location) lines.push(first);
+
+	const budgetModelLine = joinColumns(parts.budgetLine, parts.modelLine, width);
+	if (!budgetModelLine) return null;
+	lines.push(budgetModelLine);
+
+	if (parts.usageParts) {
+		lines.push(renderUsageLine(parts.usageParts, width, theme));
+	}
+
+	return lines.map((line) => truncateToWidth(line, width));
+}
+
+function renderNarrowLines(parts: RenderParts, width: number, theme: any): string[] {
+	const lines: string[] = [];
+	if (parts.location) lines.push(truncateToWidth(theme.fg("dim", parts.location), width));
+	if (parts.sessionMeta) lines.push(truncateToWidth(theme.fg("dim", parts.sessionMeta), width));
+	lines.push(truncateToWidth([parts.budgetLine, parts.modelLine].filter(Boolean).join(theme.fg("dim", " · ")), width));
+
+	if (parts.usageParts) {
+		lines.push(renderUsageLine(parts.usageParts, width, theme));
+	}
+
+	return lines;
+}
+
+function joinColumns(left: string, right: string, width: number): string | null {
+	const leftWidth = visibleWidth(left);
+	const rightWidth = visibleWidth(right);
+	if (!left && !right) return "";
+	if (!right) return truncateToWidth(left, width);
+	if (!left) return truncateToWidth(right, width);
+	const minGap = 4;
+	if (leftWidth + minGap + rightWidth > width) return null;
+	return left + " ".repeat(width - leftWidth - rightWidth) + right;
+}
+
+function renderUsageBar(usedPercent: number, theme: any): string {
+	const width = 10;
+	const remainingPercent = Math.max(0, Math.min(100, 100 - usedPercent));
+	const filled = Math.round((remainingPercent / 100) * width);
+	const color = getBudgetColor(remainingPercent);
+	return theme.fg(color, BAR_FILLED.repeat(filled)) + theme.fg("dim", BAR_EMPTY.repeat(width - filled));
+}
+
+export function renderProviderUsageLines(usage: FooterProviderUsage, width: number, theme: any): string[] {
+	const safeWidth = Math.max(1, width);
+	const parts = buildUsageParts(usage, theme);
+	return [renderUsageLine(parts, safeWidth, theme)];
+}
+
+function renderUsageLine(parts: { left: string; windows: string[] }, width: number, theme: any): string {
+	return truncateToWidth([parts.left, ...parts.windows].join(theme.fg("dim", "   ·   ")), width);
+}
+
+function buildUsageParts(usage: FooterProviderUsage, theme: any): { left: string; windows: string[] } {
+	const windows: string[] = [];
+	for (const window of usage.windows) {
+		const remainingPercent = Math.max(0, Math.min(100, 100 - window.usedPercent));
+		const pct = `${Math.round(remainingPercent)}%`;
+		const reset = window.resetsIn ? ` ${window.resetsIn}` : "";
+		windows.push(`${theme.fg("dim", window.label)} ${renderUsageBar(window.usedPercent, theme)} ${theme.fg("dim", pct + reset)}`);
+	}
+	return { left: theme.fg("dim", "usage ") + theme.fg("accent", usage.provider), windows };
+}

--- a/extensions/footer/index.ts
+++ b/extensions/footer/index.ts
@@ -1,0 +1,108 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { FooterProviderUsage } from "./helpers.ts";
+import { renderFooterLines, sumUsageFromEntries } from "./helpers.ts";
+import { detectUsageProvider, fetchProviderUsage } from "./usage.ts";
+
+const USAGE_REFRESH_INTERVAL_MS = 5 * 60_000;
+
+function isUsingSubscription(ctx: any): boolean {
+	if (!ctx.model) return false;
+	try {
+		return Boolean(ctx.modelRegistry.isUsingOAuth(ctx.model));
+	} catch {
+		return false;
+	}
+}
+
+export default function (pi: ExtensionAPI) {
+	let latestUsage: FooterProviderUsage | null = null;
+	let activeUsageProvider: ReturnType<typeof detectUsageProvider> = null;
+	let tuiRef: { requestRender: () => void } | null = null;
+	let refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+	function stopRefreshTimer(): void {
+		if (!refreshTimer) return;
+		clearInterval(refreshTimer);
+		refreshTimer = null;
+	}
+
+	function refreshUsage(modelProvider: string | undefined): void {
+		const usageProvider = detectUsageProvider(modelProvider);
+		activeUsageProvider = usageProvider;
+		if (!usageProvider) {
+			latestUsage = null;
+			stopRefreshTimer();
+			tuiRef?.requestRender();
+			return;
+		}
+
+		fetchProviderUsage(usageProvider)
+			.then((usage) => {
+				if (activeUsageProvider !== usageProvider) return;
+				latestUsage = usage;
+				tuiRef?.requestRender();
+			})
+			.catch(() => {});
+	}
+
+	function refreshActiveUsage(): void {
+		const usageProvider = activeUsageProvider;
+		if (!usageProvider) return;
+		fetchProviderUsage(usageProvider)
+			.then((usage) => {
+				if (activeUsageProvider !== usageProvider) return;
+				latestUsage = usage;
+				tuiRef?.requestRender();
+			})
+			.catch(() => {});
+	}
+
+	function startRefreshTimer(): void {
+		stopRefreshTimer();
+		if (!activeUsageProvider) return;
+		refreshTimer = setInterval(refreshActiveUsage, USAGE_REFRESH_INTERVAL_MS);
+	}
+
+	pi.on("session_start", (_event, ctx) => {
+		if (!ctx.hasUI) return;
+
+		ctx.ui.setFooter((tui, theme, footerData) => {
+			tuiRef = tui;
+			refreshUsage(ctx.model?.provider);
+			startRefreshTimer();
+			const unsubscribeBranch = footerData.onBranchChange(() => tui.requestRender());
+
+			return {
+				dispose: () => {
+					unsubscribeBranch();
+					tuiRef = null;
+					stopRefreshTimer();
+				},
+				invalidate() {},
+				render(width: number): string[] {
+					return renderFooterLines(
+						{
+							cwd: ctx.sessionManager.getCwd(),
+							branch: footerData.getGitBranch(),
+							sessionId: ctx.sessionManager.getSessionId(),
+							sessionName: ctx.sessionManager.getSessionName(),
+							usage: sumUsageFromEntries(ctx.sessionManager.getEntries()),
+							usingSubscription: isUsingSubscription(ctx),
+							model: ctx.model,
+							thinkingLevel: pi.getThinkingLevel(),
+							contextUsage: ctx.getContextUsage(),
+							providerUsage: latestUsage,
+						},
+						width,
+						theme,
+					);
+				},
+			};
+		});
+	});
+
+	pi.on("model_select", (event) => {
+		refreshUsage(event.model?.provider);
+		startRefreshTimer();
+	});
+}

--- a/extensions/footer/usage.ts
+++ b/extensions/footer/usage.ts
@@ -1,0 +1,183 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { FooterProviderUsage, FooterUsageWindow } from "./helpers.ts";
+
+const PROVIDER_MAP: Record<string, "claude" | "codex" | "copilot"> = {
+	anthropic: "claude",
+	"openai-codex": "codex",
+	"github-copilot": "copilot",
+};
+
+function clampPercent(value: number): number {
+	if (!Number.isFinite(value)) return 0;
+	return Math.max(0, Math.min(100, value));
+}
+
+function normalizePercent(value: number): number {
+	if (!Number.isFinite(value)) return 0;
+	return clampPercent(value >= 0 && value <= 1 ? value * 100 : value);
+}
+
+function formatResetTime(date: Date): string {
+	const diffMs = date.getTime() - Date.now();
+	if (diffMs <= 0) return "now";
+	const minutes = Math.floor(diffMs / 60_000);
+	if (minutes < 60) return `${minutes}m`;
+	const hours = Math.floor(minutes / 60);
+	const remainingMinutes = minutes % 60;
+	if (hours < 24) return remainingMinutes ? `${hours}h${remainingMinutes}m` : `${hours}h`;
+	const days = Math.floor(hours / 24);
+	const remainingHours = hours % 24;
+	return remainingHours ? `${days}d${remainingHours}h` : `${days}d`;
+}
+
+function loadJson(path: string): any {
+	try {
+		if (existsSync(path)) return JSON.parse(readFileSync(path, "utf8"));
+	} catch {}
+	return {};
+}
+
+function loadAgentAuth(): any {
+	return loadJson(join(homedir(), ".pi", "agent", "auth.json"));
+}
+
+function getClaudeToken(): string | undefined {
+	const auth = loadAgentAuth();
+	return auth.anthropic?.access;
+}
+
+function getCopilotToken(): string | undefined {
+	const auth = loadAgentAuth();
+	return auth["github-copilot"]?.refresh;
+}
+
+function getCodexToken(): { token: string; accountId?: string } | undefined {
+	const auth = loadAgentAuth();
+	if (auth["openai-codex"]?.access) {
+		return { token: auth["openai-codex"].access, accountId: auth["openai-codex"]?.accountId };
+	}
+
+	const codexAuth = loadJson(join(process.env.CODEX_HOME || join(homedir(), ".codex"), "auth.json"));
+	if (codexAuth.OPENAI_API_KEY) return { token: codexAuth.OPENAI_API_KEY };
+	if (codexAuth.tokens?.access_token) {
+		return { token: codexAuth.tokens.access_token, accountId: codexAuth.tokens.account_id };
+	}
+	return undefined;
+}
+
+async function fetchJson(url: string, init: RequestInit): Promise<any | null> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), 5000);
+	try {
+		const response = await fetch(url, { ...init, signal: controller.signal });
+		if (!response.ok) return null;
+		return await response.json();
+	} catch {
+		return null;
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+async function fetchClaudeUsage(): Promise<FooterProviderUsage | null> {
+	const token = getClaudeToken();
+	if (!token) return null;
+	const data = await fetchJson("https://api.anthropic.com/api/oauth/usage", {
+		headers: { Authorization: `Bearer ${token}`, "anthropic-beta": "oauth-2025-04-20" },
+	});
+	if (!data) return null;
+
+	const windows: FooterUsageWindow[] = [];
+	if (data.five_hour?.utilization !== undefined) {
+		windows.push({
+			label: "5h",
+			usedPercent: normalizePercent(data.five_hour.utilization),
+			resetsIn: data.five_hour.resets_at ? formatResetTime(new Date(data.five_hour.resets_at)) : undefined,
+		});
+	}
+	if (data.seven_day?.utilization !== undefined) {
+		windows.push({
+			label: "Week",
+			usedPercent: normalizePercent(data.seven_day.utilization),
+			resetsIn: data.seven_day.resets_at ? formatResetTime(new Date(data.seven_day.resets_at)) : undefined,
+		});
+	}
+	return windows.length ? { provider: "Claude", windows } : null;
+}
+
+async function fetchCopilotUsage(): Promise<FooterProviderUsage | null> {
+	const token = getCopilotToken();
+	if (!token) return null;
+	const data = await fetchJson("https://api.github.com/copilot_internal/user", {
+		headers: {
+			"Editor-Version": "vscode/1.96.2",
+			"User-Agent": "GitHubCopilotChat/0.26.7",
+			"X-Github-Api-Version": "2025-04-01",
+			Accept: "application/json",
+			Authorization: `token ${token}`,
+		},
+	});
+	if (!data) return null;
+
+	const resetDate = data.quota_reset_date_utc ? new Date(data.quota_reset_date_utc) : undefined;
+	const resetsIn = resetDate ? formatResetTime(resetDate) : undefined;
+	const windows: FooterUsageWindow[] = [];
+	const premium = data.quota_snapshots?.premium_interactions;
+	if (premium) windows.push({ label: "Premium", usedPercent: clampPercent(100 - (premium.percent_remaining || 0)), resetsIn });
+	const chat = data.quota_snapshots?.chat;
+	if (chat && !chat.unlimited) windows.push({ label: "Chat", usedPercent: clampPercent(100 - (chat.percent_remaining || 0)), resetsIn });
+	return windows.length ? { provider: "Copilot", windows } : null;
+}
+
+function getWindowLabel(seconds: number | undefined, fallback: string): string {
+	if (!seconds || !Number.isFinite(seconds)) return fallback;
+	const hours = Math.round(seconds / 3600);
+	if (hours >= 1 && hours < 24) return `${hours}h`;
+	const days = Math.round(hours / 24);
+	return days >= 1 ? `${days}d` : fallback;
+}
+
+async function fetchCodexUsage(): Promise<FooterProviderUsage | null> {
+	const creds = getCodexToken();
+	if (!creds) return null;
+	const headers: Record<string, string> = {
+		Authorization: `Bearer ${creds.token}`,
+		"User-Agent": "pi-agent",
+		Accept: "application/json",
+	};
+	if (creds.accountId) headers["ChatGPT-Account-Id"] = creds.accountId;
+	const data = await fetchJson("https://chatgpt.com/backend-api/wham/usage", { method: "GET", headers });
+	if (!data) return null;
+
+	const windows: FooterUsageWindow[] = [];
+	for (const [key, fallback] of [
+		["primary_window", "5h"],
+		["secondary_window", "Week"],
+	] as const) {
+		const window = data.rate_limit?.[key];
+		if (!window) continue;
+		windows.push({
+			label: getWindowLabel(window.limit_window_seconds, fallback),
+			usedPercent: clampPercent(window.used_percent || 0),
+			resetsIn: window.reset_at ? formatResetTime(new Date(window.reset_at * 1000)) : undefined,
+		});
+	}
+	return windows.length ? { provider: "Codex", windows } : null;
+}
+
+export function detectUsageProvider(modelProvider: string | undefined): "claude" | "codex" | "copilot" | null {
+	return modelProvider ? (PROVIDER_MAP[modelProvider] ?? null) : null;
+}
+
+export async function fetchProviderUsage(provider: "claude" | "codex" | "copilot"): Promise<FooterProviderUsage | null> {
+	switch (provider) {
+		case "claude":
+			return fetchClaudeUsage();
+		case "codex":
+			return fetchCodexUsage();
+		case "copilot":
+			return fetchCopilotUsage();
+	}
+}


### PR DESCRIPTION
Adds a project footer extension that preserves token and cost status details, includes write-cache totals, keeps provider-qualified model labels, and moves context usage into a threshold-colored bar without the default auto-compaction percentage segment.

Verification: npm test; npm run typecheck

closes #265
