### PR TITLE
✨ feat(worktrunk): Add issue worktree command

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,0 +1,8 @@
+[[pre-start]]
+trust = "mise trust"
+
+[[pre-start]]
+mise = "mise install"
+
+[[pre-start]]
+deps = "npm ci"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioned sections should match the Git tags and GitHub releases published for t
 
 ### Added
 
+- Added a repo-local Worktrunk extension with `/worktree issue <issue-number-or-url>`, issue-derived branch names, create-or-reuse behavior, Worktrunk `pre-start` setup hooks, and workflow documentation for parallel Pi issue work. ([#85](https://github.com/ladislas/mypac/issues/85))
 - Added a custom Pi footer extension with write-cache token totals, provider-qualified model labels, context/budget threshold coloring, Codex/Copilot/Claude usage bars, and no default auto-compaction percentage segment. ([#265](https://github.com/ladislas/mypac/issues/265))
 - Added hooks that block `fixup!` commits from being merged or pushed into `main` through the local workflow. ([#259](https://github.com/ladislas/mypac/issues/259))
 - Added optional Standards + Spec follow-up review support with a dedicated `pac-review-standards-spec` skill and `/review-end` summaries that preserve default, standards, and spec findings separately. ([#255](https://github.com/ladislas/mypac/issues/255))

--- a/extensions/worktrunk/README.md
+++ b/extensions/worktrunk/README.md
@@ -1,0 +1,78 @@
+# Worktrunk extension
+
+Repo-local Pi extension for creating issue-specific Worktrunk worktrees.
+
+This is intentionally a `mypac` workflow, not a generic Worktrunk wrapper. Worktrunk owns worktree lifecycle behavior; this extension only adds a small Pi command for GitHub issue-backed work.
+
+## Command
+
+```text
+/worktree issue <issue-number-or-url>
+```
+
+Examples:
+
+```text
+/worktree issue 85
+/worktree issue https://github.com/ladislas/mypac/issues/85
+```
+
+The command:
+
+1. Reads issue metadata with `gh`.
+2. Builds a branch name from the issue number and title:
+
+   ```text
+   ladislas/feature/<issue-number>-<issue-title-slug>
+   ```
+
+3. Lists Worktrunk worktrees with `wt list --format=json`.
+4. Reuses the existing worktree if that branch already exists.
+5. Otherwise creates one with:
+
+   ```text
+   wt switch --create --no-cd <branch>
+   ```
+
+6. Prints the issue title, branch, worktree path, and next command:
+
+   ```text
+   cd <worktree-path> && pi
+   ```
+
+## Setup behavior
+
+The extension does not run project setup commands directly. Setup belongs to Worktrunk hooks so each repository can own its own policy.
+
+For this repo, `.config/wt.toml` defines blocking `pre-start` hooks for new worktrees:
+
+```text
+mise trust
+mise install
+npm ci
+```
+
+Worktrunk may ask for approval before running project hooks. That is expected.
+
+## Requirements
+
+- `gh` authenticated for the target GitHub repository
+- `wt` installed and configured
+- `mise` and `npm` available for this repo's `pre-start` hooks
+
+## Scope
+
+In scope:
+
+- GitHub issue number or issue URL input
+- Issue-derived branch names
+- Create-or-reuse Worktrunk worktrees
+- Clear next-step output for launching Pi manually
+
+Out of scope:
+
+- Launching Pi automatically
+- Opening terminal tabs or Zellij panes
+- Raw `git worktree` management
+- Worktree removal or cleanup flows
+- Reimplementing Worktrunk configuration, hooks, or lifecycle behavior

--- a/extensions/worktrunk/helpers.ts
+++ b/extensions/worktrunk/helpers.ts
@@ -1,0 +1,92 @@
+export type IssueTarget =
+	| { kind: "number"; number: number }
+	| { kind: "url"; owner: string; repo: string; number: number };
+
+export type WorktrunkListEntry = {
+	branch: string | null;
+	path?: string;
+};
+
+export function parseIssueTarget(input: string): IssueTarget | null {
+	const value = input.trim();
+	if (!value) return null;
+
+	if (/^\d+$/.test(value)) {
+		return { kind: "number", number: Number(value) };
+	}
+
+	let url: URL;
+	try {
+		url = new URL(value);
+	} catch {
+		return null;
+	}
+
+	if (url.hostname !== "github.com") return null;
+	const parts = url.pathname.split("/").filter(Boolean);
+	if (parts.length < 4 || parts[2] !== "issues" || !/^\d+$/.test(parts[3])) return null;
+
+	return {
+		kind: "url",
+		owner: parts[0],
+		repo: parts[1],
+		number: Number(parts[3]),
+	};
+}
+
+export function slugifyIssueTitle(title: string): string {
+	return title
+		.toLowerCase()
+		.normalize("NFKD")
+		.replace(/[\u0300-\u036f]/g, "")
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.replace(/-{2,}/g, "-");
+}
+
+export function buildIssueBranch(number: number, title: string, firstName = "ladislas"): string {
+	const slug = slugifyIssueTitle(title) || `issue-${number}`;
+	return `${firstName}/feature/${number}-${slug}`;
+}
+
+export function parseWorktrunkList(output: string): WorktrunkListEntry[] {
+	const parsed = JSON.parse(output || "[]") as unknown;
+	if (!Array.isArray(parsed)) {
+		throw new Error("expected wt list output to be a JSON array");
+	}
+
+	return parsed.map((item) => {
+		const record = item && typeof item === "object" ? (item as Record<string, unknown>) : {};
+		return {
+			branch: typeof record.branch === "string" ? record.branch : null,
+			path: typeof record.path === "string" && record.path.length > 0 ? record.path : undefined,
+		};
+	});
+}
+
+export function findWorktreeByBranch(entries: WorktrunkListEntry[], branch: string): WorktrunkListEntry | undefined {
+	return entries.find((entry) => entry.branch === branch);
+}
+
+export function formatIssueWorktreeSummary(input: {
+	created: boolean;
+	issueNumber: number;
+	issueTitle: string;
+	branch: string;
+	path: string;
+}): string {
+	const status = input.created ? "Created worktree" : "Reusing existing worktree";
+	return [
+		`${status} for #${input.issueNumber}: ${input.issueTitle}`,
+		`Branch: ${input.branch}`,
+		`Path: ${input.path}`,
+		"",
+		"Next:",
+		`cd ${shellQuote(input.path)} && pi`,
+	].join("\n");
+}
+
+function shellQuote(value: string): string {
+	if (/^[A-Za-z0-9_/:=.,+@%-]+$/.test(value)) return value;
+	return `'${value.replace(/'/g, `'"'"'`)}'`;
+}

--- a/extensions/worktrunk/helpers.ts
+++ b/extensions/worktrunk/helpers.ts
@@ -50,7 +50,7 @@ export function buildIssueBranch(number: number, title: string, firstName = "lad
 }
 
 export function parseWorktrunkList(output: string): WorktrunkListEntry[] {
-	const parsed = JSON.parse(output || "[]") as unknown;
+	const parsed = JSON.parse(output.trim() || "[]") as unknown;
 	if (!Array.isArray(parsed)) {
 		throw new Error("expected wt list output to be a JSON array");
 	}

--- a/extensions/worktrunk/index.ts
+++ b/extensions/worktrunk/index.ts
@@ -1,0 +1,133 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+	buildIssueBranch,
+	findWorktreeByBranch,
+	formatIssueWorktreeSummary,
+	parseIssueTarget,
+	parseWorktrunkList,
+} from "./helpers.ts";
+
+type IssueMetadata = {
+	number: number;
+	title: string;
+	url: string;
+};
+
+type CommandResult<T> = { ok: true; value: T } | { ok: false; error: string };
+
+export default function worktrunkExtension(pi: ExtensionAPI): void {
+	pi.registerCommand("worktree", {
+		description: "Manage Worktrunk worktrees",
+		handler: async (args, ctx) => {
+			const tokens = (args ?? "").trim().split(/\s+/).filter(Boolean);
+			if (tokens[0] !== "issue") {
+				ctx.ui.notify("Usage: /worktree issue <issue-number-or-url>", "info");
+				return;
+			}
+
+			const target = parseIssueTarget(tokens.slice(1).join(" "));
+			if (!target) {
+				ctx.ui.notify("Usage: /worktree issue <issue-number-or-url>", "error");
+				return;
+			}
+
+			const repoResult = target.kind === "url" ? { ok: true as const, value: `${target.owner}/${target.repo}` } : await inferRepo(pi);
+			if (!repoResult.ok) {
+				ctx.ui.notify(repoResult.error, "error");
+				return;
+			}
+
+			const issueResult = await fetchIssue(pi, repoResult.value, target.number);
+			if (!issueResult.ok) {
+				ctx.ui.notify(issueResult.error, "error");
+				return;
+			}
+
+			const issue = issueResult.value;
+			const branch = buildIssueBranch(issue.number, issue.title);
+			const worktreeResult = await ensureWorktree(pi, branch);
+			if (!worktreeResult.ok) {
+				ctx.ui.notify(worktreeResult.error, "error");
+				return;
+			}
+
+			ctx.ui.notify(
+				formatIssueWorktreeSummary({
+					created: worktreeResult.value.created,
+					issueNumber: issue.number,
+					issueTitle: issue.title,
+					branch,
+					path: worktreeResult.value.path,
+				}),
+				"info",
+			);
+		},
+	});
+}
+
+async function inferRepo(pi: ExtensionAPI): Promise<CommandResult<string>> {
+	const result = await pi.exec("gh", ["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"], {
+		timeout: 30_000,
+	});
+	if (result.code !== 0) return { ok: false, error: formatExecError("Could not infer GitHub repository", result) };
+
+	const repo = result.stdout.trim();
+	if (!/^[^/]+\/[^/]+$/.test(repo)) return { ok: false, error: "Could not infer GitHub repository." };
+	return { ok: true, value: repo };
+}
+
+async function fetchIssue(pi: ExtensionAPI, repo: string, number: number): Promise<CommandResult<IssueMetadata>> {
+	const result = await pi.exec(
+		"gh",
+		["issue", "view", String(number), "--repo", repo, "--json", "number,title,url"],
+		{ timeout: 30_000 },
+	);
+	if (result.code !== 0) return { ok: false, error: formatExecError(`Could not read issue #${number}`, result) };
+
+	try {
+		const parsed = JSON.parse(result.stdout) as Partial<IssueMetadata>;
+		if (typeof parsed.number !== "number" || typeof parsed.title !== "string" || typeof parsed.url !== "string") {
+			return { ok: false, error: `Could not parse issue #${number} metadata from gh output.` };
+		}
+		return { ok: true, value: { number: parsed.number, title: parsed.title, url: parsed.url } };
+	} catch (error) {
+		return { ok: false, error: `Could not parse issue #${number} metadata: ${error instanceof Error ? error.message : String(error)}` };
+	}
+}
+
+async function ensureWorktree(pi: ExtensionAPI, branch: string): Promise<CommandResult<{ created: boolean; path: string }>> {
+	const before = await listWorktrees(pi);
+	if (!before.ok) return before;
+
+	const existing = findWorktreeByBranch(before.value, branch);
+	if (existing?.path) return { ok: true, value: { created: false, path: existing.path } };
+
+	const create = await pi.exec("wt", ["switch", "--create", "--no-cd", branch], { timeout: 120_000 });
+	if (create.code !== 0) return { ok: false, error: formatExecError(`Could not create Worktrunk worktree for ${branch}`, create) };
+
+	const after = await listWorktrees(pi);
+	if (!after.ok) return after;
+
+	const created = findWorktreeByBranch(after.value, branch);
+	if (!created?.path) {
+		return { ok: false, error: `Worktrunk completed, but ${branch} was not found in wt list output.` };
+	}
+
+	return { ok: true, value: { created: true, path: created.path } };
+}
+
+async function listWorktrees(pi: ExtensionAPI): Promise<CommandResult<ReturnType<typeof parseWorktrunkList>>> {
+	const result = await pi.exec("wt", ["list", "--format=json"], { timeout: 30_000 });
+	if (result.code !== 0) return { ok: false, error: formatExecError("Could not list Worktrunk worktrees", result) };
+
+	try {
+		return { ok: true, value: parseWorktrunkList(result.stdout) };
+	} catch (error) {
+		return { ok: false, error: `Could not parse wt list output: ${error instanceof Error ? error.message : String(error)}` };
+	}
+}
+
+function formatExecError(prefix: string, result: { code: number; stdout: string; stderr: string }): string {
+	const details = [result.stderr.trim(), result.stdout.trim()].filter(Boolean).join("\n");
+	return details ? `${prefix}: ${details}` : `${prefix}. Exit code: ${result.code}`;
+}

--- a/extensions/worktrunk/index.ts
+++ b/extensions/worktrunk/index.ts
@@ -95,11 +95,14 @@ async function fetchIssue(pi: ExtensionAPI, repo: string, number: number): Promi
 	}
 }
 
-async function ensureWorktree(pi: ExtensionAPI, branch: string): Promise<CommandResult<{ created: boolean; path: string }>> {
+export async function ensureWorktree(pi: ExtensionAPI, branch: string): Promise<CommandResult<{ created: boolean; path: string }>> {
 	const before = await listWorktrees(pi);
 	if (!before.ok) return before;
 
 	const existing = findWorktreeByBranch(before.value, branch);
+	if (existing && !existing.path) {
+		return { ok: false, error: `Worktree for ${branch} exists but has no path in wt list output.` };
+	}
 	if (existing?.path) return { ok: true, value: { created: false, path: existing.path } };
 
 	const create = await pi.exec("wt", ["switch", "--create", "--no-cd", branch], { timeout: 120_000 });

--- a/extensions/worktrunk/worktrunk.test.mjs
+++ b/extensions/worktrunk/worktrunk.test.mjs
@@ -8,6 +8,7 @@ import {
 	parseWorktrunkList,
 	slugifyIssueTitle,
 } from "./helpers.ts";
+import { ensureWorktree } from "./index.ts";
 
 test("parses a local issue number", () => {
 	assert.deepEqual(parseIssueTarget("85"), { kind: "number", number: 85 });
@@ -42,10 +43,10 @@ test("builds repo-convention issue branch names", () => {
 });
 
 test("parses Worktrunk list output", () => {
-	const entries = parseWorktrunkList(JSON.stringify([
+	const entries = parseWorktrunkList(`\n${JSON.stringify([
 		{ branch: "main", path: "/repo", is_current: true },
 		{ branch: "ladislas/feature/85-work", path: "/repo/.worktrees/85-work" },
-	]));
+	])}\n`);
 
 	assert.deepEqual(entries, [
 		{ branch: "main", path: "/repo" },
@@ -55,6 +56,29 @@ test("parses Worktrunk list output", () => {
 		branch: "ladislas/feature/85-work",
 		path: "/repo/.worktrees/85-work",
 	});
+});
+
+test("reports an existing Worktrunk entry without a path before trying to create", async () => {
+	const calls = [];
+	const pi = {
+		async exec(command, args) {
+			calls.push([command, args]);
+			assert.deepEqual([command, args], ["wt", ["list", "--format=json"]]);
+			return {
+				code: 0,
+				stdout: JSON.stringify([{ branch: "ladislas/feature/85-work" }]),
+				stderr: "",
+			};
+		},
+	};
+
+	const result = await ensureWorktree(pi, "ladislas/feature/85-work");
+
+	assert.deepEqual(result, {
+		ok: false,
+		error: "Worktree for ladislas/feature/85-work exists but has no path in wt list output.",
+	});
+	assert.equal(calls.length, 1);
 });
 
 test("formats next Pi command with shell quoting", () => {

--- a/extensions/worktrunk/worktrunk.test.mjs
+++ b/extensions/worktrunk/worktrunk.test.mjs
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+	buildIssueBranch,
+	findWorktreeByBranch,
+	formatIssueWorktreeSummary,
+	parseIssueTarget,
+	parseWorktrunkList,
+	slugifyIssueTitle,
+} from "./helpers.ts";
+
+test("parses a local issue number", () => {
+	assert.deepEqual(parseIssueTarget("85"), { kind: "number", number: 85 });
+});
+
+test("parses a GitHub issue URL", () => {
+	assert.deepEqual(parseIssueTarget("https://github.com/ladislas/mypac/issues/85"), {
+		kind: "url",
+		owner: "ladislas",
+		repo: "mypac",
+		number: 85,
+	});
+});
+
+test("rejects invalid issue targets", () => {
+	assert.equal(parseIssueTarget(""), null);
+	assert.equal(parseIssueTarget("not-an-issue"), null);
+	assert.equal(parseIssueTarget("https://example.com/ladislas/mypac/issues/85"), null);
+	assert.equal(parseIssueTarget("https://github.com/ladislas/mypac/pull/85"), null);
+});
+
+test("slugifies issue titles", () => {
+	assert.equal(slugifyIssueTitle("Adopt a Worktrunk-backed workflow for parallel Pi issue work"), "adopt-a-worktrunk-backed-workflow-for-parallel-pi-issue-work");
+	assert.equal(slugifyIssueTitle("Fix: mise + npm setup!"), "fix-mise-npm-setup");
+});
+
+test("builds repo-convention issue branch names", () => {
+	assert.equal(
+		buildIssueBranch(85, "Adopt a Worktrunk-backed workflow"),
+		"ladislas/feature/85-adopt-a-worktrunk-backed-workflow",
+	);
+});
+
+test("parses Worktrunk list output", () => {
+	const entries = parseWorktrunkList(JSON.stringify([
+		{ branch: "main", path: "/repo", is_current: true },
+		{ branch: "ladislas/feature/85-work", path: "/repo/.worktrees/85-work" },
+	]));
+
+	assert.deepEqual(entries, [
+		{ branch: "main", path: "/repo" },
+		{ branch: "ladislas/feature/85-work", path: "/repo/.worktrees/85-work" },
+	]);
+	assert.deepEqual(findWorktreeByBranch(entries, "ladislas/feature/85-work"), {
+		branch: "ladislas/feature/85-work",
+		path: "/repo/.worktrees/85-work",
+	});
+});
+
+test("formats next Pi command with shell quoting", () => {
+	assert.equal(
+		formatIssueWorktreeSummary({
+			created: true,
+			issueNumber: 85,
+			issueTitle: "Adopt Worktrunk",
+			branch: "ladislas/feature/85-adopt-worktrunk",
+			path: "/tmp/my worktree",
+		}),
+		[
+			"Created worktree for #85: Adopt Worktrunk",
+			"Branch: ladislas/feature/85-adopt-worktrunk",
+			"Path: /tmp/my worktree",
+			"",
+			"Next:",
+			"cd '/tmp/my worktree' && pi",
+		].join("\n"),
+	);
+});


### PR DESCRIPTION
Add a repo-local /worktree issue command that reads GitHub issue metadata, creates or reuses a Worktrunk worktree, and reports the next Pi command.

Configure Worktrunk pre-start hooks to prepare new mypac worktrees with mise and npm ci.

Verification: npm test; npm run typecheck

closes #85
