### PR TITLE
🐛 fix(worktrunk): Pre-approve worktree setup hooks

### DIFF
--- a/extensions/worktrunk/README.md
+++ b/extensions/worktrunk/README.md
@@ -31,7 +31,7 @@ The command:
 5. Otherwise creates one with:
 
    ```text
-   wt switch --create --no-cd <branch>
+   wt switch --create --no-cd --yes <branch>
    ```
 
 6. Prints the issue title, branch, worktree path, and next command:
@@ -52,7 +52,7 @@ mise install
 npm ci
 ```
 
-Worktrunk may ask for approval before running project hooks. That is expected.
+Because Pi slash commands run non-interactively, the extension passes `--yes` to pre-approve these repo-owned hooks.
 
 ## Requirements
 

--- a/extensions/worktrunk/index.ts
+++ b/extensions/worktrunk/index.ts
@@ -105,7 +105,7 @@ export async function ensureWorktree(pi: ExtensionAPI, branch: string): Promise<
 	}
 	if (existing?.path) return { ok: true, value: { created: false, path: existing.path } };
 
-	const create = await pi.exec("wt", ["switch", "--create", "--no-cd", branch], { timeout: 120_000 });
+	const create = await pi.exec("wt", ["switch", "--create", "--no-cd", "--yes", branch], { timeout: 120_000 });
 	if (create.code !== 0) return { ok: false, error: formatExecError(`Could not create Worktrunk worktree for ${branch}`, create) };
 
 	const after = await listWorktrees(pi);

--- a/extensions/worktrunk/worktrunk.test.mjs
+++ b/extensions/worktrunk/worktrunk.test.mjs
@@ -58,6 +58,35 @@ test("parses Worktrunk list output", () => {
 	});
 });
 
+test("creates new worktrees with non-interactive hook approval", async () => {
+	const calls = [];
+	const listBefore = JSON.stringify([{ branch: "main", path: "/repo" }]);
+	const listAfter = JSON.stringify([
+		{ branch: "main", path: "/repo" },
+		{ branch: "ladislas/feature/85-work", path: "/repo/.worktrees/85-work" },
+	]);
+	const pi = {
+		async exec(command, args) {
+			calls.push([command, args]);
+			if (calls.length === 1) return { code: 0, stdout: listBefore, stderr: "" };
+			if (calls.length === 2) return { code: 0, stdout: "", stderr: "" };
+			return { code: 0, stdout: listAfter, stderr: "" };
+		},
+	};
+
+	const result = await ensureWorktree(pi, "ladislas/feature/85-work");
+
+	assert.deepEqual(result, {
+		ok: true,
+		value: { created: true, path: "/repo/.worktrees/85-work" },
+	});
+	assert.deepEqual(calls, [
+		["wt", ["list", "--format=json"]],
+		["wt", ["switch", "--create", "--no-cd", "--yes", "ladislas/feature/85-work"]],
+		["wt", ["list", "--format=json"]],
+	]);
+});
+
 test("reports an existing Worktrunk entry without a path before trying to create", async () => {
 	const calls = [];
 	const pi = {


### PR DESCRIPTION
Pass --yes to Worktrunk creation from the non-interactive Pi slash command so repo-owned pre-start hooks can run.

Verification: npm test && npm run typecheck
