### PR TITLE
📝 docs(review): Add feature flag review callouts

### DIFF
--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -82,6 +82,8 @@ applicable callouts:
 - **This change modifies auth/permission behavior:** <what changed and where>
 - **This change introduces backwards-incompatible public schema/API/contract changes:** <what changed and where>
 - **This change includes irreversible or destructive operations:** <operation and scope>
+- **This change adds or removes feature flags:** <feature flags changed> (call out re-use of dormant feature flags!)
+- **This change changes configuration defaults:** <config var changed>
 ```
 
 These callouts are informational for the human reviewer. Do not treat them as

--- a/extensions/review/REVIEW_SUMMARY_PROMPT.md
+++ b/extensions/review/REVIEW_SUMMARY_PROMPT.md
@@ -61,6 +61,8 @@ Include only applicable callouts (no yes/no lines):
 - **This change introduces backwards-incompatible public schema/API/contract changes:**
   `what changed and where`
 - **This change includes irreversible or destructive operations:** `operation and scope`
+- **This change adds or removes feature flags:** `feature flags changed` (call out re-use of dormant feature flags!)
+- **This change changes configuration defaults:** `config var changed`
 
 If none apply, write "- (none)".
 

--- a/extensions/review/prompts.test.mjs
+++ b/extensions/review/prompts.test.mjs
@@ -47,5 +47,7 @@ test("review summary prompt preserves separate review passes", async () => {
 	assert.match(prompt, /## Standards Findings/);
 	assert.match(prompt, /## Spec Findings/);
 	assert.match(prompt, /## Combined Fix Queue/);
+	assert.match(prompt, /This change adds or removes feature flags/);
+	assert.match(prompt, /This change changes configuration defaults/);
 	assert.match(prompt, /preserve.*separate/i);
 });

--- a/skills/pac-review/SKILL.md
+++ b/skills/pac-review/SKILL.md
@@ -126,6 +126,8 @@ Include only applicable callouts (no yes/no lines):
 - **This change modifies auth/permission behavior:** <what changed and where>
 - **This change introduces backwards-incompatible public schema/API/contract changes:** <what changed and where>
 - **This change includes irreversible or destructive operations:** <operation and scope>
+- **This change adds or removes feature flags:** <feature flags changed> (call out re-use of dormant feature flags!)
+- **This change changes configuration defaults:** <config var changed>
 
 Rules for this section:
 


### PR DESCRIPTION
Adapt the narrow upstream pi-review human-reviewer-callout wording for feature flag changes and configuration default changes. Answer extraction model IDs and pac-to-prd guidance were checked and do not need local changes.

Verification: git diff --check; npm test -- --test-reporter=spec extensions/review/prompts.test.mjs

closes #235
