### PR TITLE
📝 docs(provenance): Move source credits into registry

### DIFF
--- a/.pac/upstream-sources.yaml
+++ b/.pac/upstream-sources.yaml
@@ -34,7 +34,7 @@ local_artifacts:
     attribution:
       upstream: mitsuhiko/agent-stuff
       license: Review upstream repository before copying new code.
-      notes: Local file includes original-source credit; README gives broad credit.
+      notes: Registry carries the source credit; README gives broad credit.
     known_divergence:
       - Local extension layout may differ from upstream single-file extension layout.
 
@@ -65,7 +65,7 @@ local_artifacts:
     attribution:
       upstream: mitsuhiko/agent-stuff
       license: Review upstream repository before copying new code.
-      notes: Local file includes original-source credit; README gives broad credit.
+      notes: Registry carries the source credit; README gives broad credit.
     known_divergence:
       - Local extension layout may differ from upstream single-file extension layout.
 
@@ -96,7 +96,7 @@ local_artifacts:
     attribution:
       upstream: mitsuhiko/agent-stuff
       license: Review upstream repository before copying new code.
-      notes: Local file includes original-source credit; README gives broad credit.
+      notes: Registry carries the source credit; README gives broad credit.
     known_divergence:
       - Local extension layout may differ from upstream single-file extension layout.
 
@@ -127,7 +127,7 @@ local_artifacts:
     attribution:
       upstream: mitsuhiko/agent-stuff
       license: Review upstream repository before copying new code.
-      notes: Local file includes original-source credit; README gives broad credit.
+      notes: Registry carries the source credit; README gives broad credit.
     known_divergence:
       - Local extension layout may differ from upstream single-file extension layout.
 
@@ -158,7 +158,7 @@ local_artifacts:
     attribution:
       upstream: mitsuhiko/agent-stuff
       license: Review upstream repository before copying new code.
-      notes: Local file includes original-source credit; README gives broad credit.
+      notes: Registry carries the source credit; README gives broad credit.
     known_divergence:
       - Local extension layout differs from upstream single-file extension layout to allow tested helper modules.
 
@@ -189,7 +189,7 @@ local_artifacts:
     attribution:
       upstream: mitsuhiko/agent-stuff
       license: Review upstream repository before copying new code.
-      notes: Local file includes original-source credit; README gives broad credit.
+      notes: Registry carries the source credit; README gives broad credit.
     known_divergence:
       - Local extension layout may differ from upstream single-file extension layout.
 
@@ -208,8 +208,13 @@ local_artifacts:
         ref: main
         paths:
           - extensions/uv.ts
+          - intercepted-commands/pip
+          - intercepted-commands/pip3
+          - intercepted-commands/poetry
+          - intercepted-commands/python
+          - intercepted-commands/python3
         attribution:
-          upstream: mitsuhiko/agent-stuff/extensions/uv.ts
+          upstream: mitsuhiko/agent-stuff/extensions/uv.ts and intercepted-commands/*
           license: Review upstream repository before copying new code.
           notes: Local extension may be split into helper modules and tests to satisfy mypac extension layout rules.
         last_reviewed:
@@ -220,7 +225,7 @@ local_artifacts:
     attribution:
       upstream: mitsuhiko/agent-stuff
       license: Review upstream repository before copying new code.
-      notes: Local file includes original-source credit; README gives broad credit.
+      notes: Registry carries the source credit; README gives broad credit.
     known_divergence:
       - Local extension layout may differ from upstream single-file extension layout.
 
@@ -251,7 +256,7 @@ local_artifacts:
     attribution:
       upstream: mitsuhiko/agent-stuff
       license: Review upstream repository before copying new code.
-      notes: Local file includes original-source credit; README gives broad credit.
+      notes: Registry carries the source credit; README gives broad credit.
     known_divergence:
       - Local extension layout may differ from upstream single-file extension layout.
 
@@ -305,6 +310,81 @@ local_artifacts:
     do_not_chase:
       - "Per #118 and PR #190, do not chase wholesale feature parity with upstream review implementations."
       - Missing upstream loop-fixing, custom-persistence, broad local-changes review, or other removed complexity is intentional unless a concrete prompt, rubric, bugfix, or robustness change is identified.
+
+  - id: pi-theme-nightowl
+    title: Night Owl theme
+    kind: theme
+    local:
+      paths:
+        - themes/nightowl.json
+    upstream_refs:
+      - id: agent-stuff-nightowl-theme
+        role: source_adaptation
+        status: active
+        sync_policy: targeted
+        repo: https://github.com/mitsuhiko/agent-stuff
+        ref: main
+        paths:
+          - themes/nightowl.json
+        attribution:
+          upstream: mitsuhiko/agent-stuff/themes/nightowl.json
+          license: Review upstream repository before copying new theme values.
+          notes: Local theme tracks the Agent Stuff Night Owl theme as its source adaptation.
+        last_reviewed:
+          upstream_commit: null
+          checkpoint_issue: null
+          reviewed_at: null
+          notes: Registered from #263 after moving inline theme provenance into the registry.
+
+  - id: pi-theme-nord
+    title: Nord theme
+    kind: theme
+    local:
+      paths:
+        - themes/nord.json
+    upstream_refs:
+      - id: oh-pi-nord-theme
+        role: source_adaptation
+        status: active
+        sync_policy: targeted
+        repo: https://github.com/ifiokjr/oh-pi
+        ref: main
+        paths:
+          - packages/themes/themes/nord.json
+        attribution:
+          upstream: ifiokjr/oh-pi/packages/themes/themes/nord.json
+          license: Review upstream repository before copying new theme values.
+          notes: Local theme tracks the oh-pi Nord theme as its source adaptation.
+        last_reviewed:
+          upstream_commit: null
+          checkpoint_issue: null
+          reviewed_at: null
+          notes: Registered from #263 after moving inline theme provenance into the registry.
+
+  - id: pi-theme-gruvbox-dark
+    title: Gruvbox Dark theme
+    kind: theme
+    local:
+      paths:
+        - themes/gruvbox-dark.json
+    upstream_refs:
+      - id: oh-pi-gruvbox-dark-theme
+        role: source_adaptation
+        status: active
+        sync_policy: targeted
+        repo: https://github.com/ifiokjr/oh-pi
+        ref: main
+        paths:
+          - packages/themes/themes/gruvbox-dark.json
+        attribution:
+          upstream: ifiokjr/oh-pi/packages/themes/themes/gruvbox-dark.json
+          license: Review upstream repository before copying new theme values.
+          notes: Local theme tracks the oh-pi Gruvbox Dark theme as its source adaptation.
+        last_reviewed:
+          upstream_commit: null
+          checkpoint_issue: null
+          reviewed_at: null
+          notes: Registered from #263 after moving inline theme provenance into the registry.
 
   - id: pi-skill-review
     title: Review skill

--- a/extensions/answer/index.ts
+++ b/extensions/answer/index.ts
@@ -1,6 +1,5 @@
 /**
  * Q&A extraction hook - extracts questions from assistant responses
- * Original source: https://github.com/mitsuhiko/agent-stuff/blob/main/extensions/answer.ts
  *
  * Custom interactive TUI for answering questions.
  *

--- a/extensions/btw/index.ts
+++ b/extensions/btw/index.ts
@@ -1,5 +1,4 @@
 /**
- * Original source: https://github.com/mitsuhiko/agent-stuff/blob/main/extensions/btw.ts
  */
 import { existsSync } from "node:fs";
 import path from "node:path";

--- a/extensions/files/index.ts
+++ b/extensions/files/index.ts
@@ -1,6 +1,5 @@
 /**
  * Files Extension
- * Original source: https://github.com/mitsuhiko/agent-stuff/blob/main/extensions/files.ts
  *
  * /files command lists files in the current git tree (plus session-referenced files)
  * and offers quick actions like reveal, open, edit, or diff.

--- a/extensions/multi-edit/index.ts
+++ b/extensions/multi-edit/index.ts
@@ -1,6 +1,5 @@
 /**
  * Multi-Edit Extension — replaces the built-in `edit` tool.
- * Original source: https://github.com/mitsuhiko/agent-stuff/blob/main/extensions/multi-edit.ts
  *
  * Supports all original parameters (path, oldText, newText) plus:
  * - `multi`: array of {path, oldText, newText} edits applied in sequence

--- a/extensions/notify/index.ts
+++ b/extensions/notify/index.ts
@@ -1,5 +1,4 @@
 /**
- * Original source: https://github.com/mitsuhiko/agent-stuff/blob/main/extensions/notify.ts
  * Additional reference: https://github.com/ferologics/pi-notify/blob/master/index.ts
  *
  * Sends a terminal desktop notification when Pi is ready for input.

--- a/extensions/review/index.ts
+++ b/extensions/review/index.ts
@@ -1,6 +1,5 @@
 /**
- * Code Review Extension (inspired by Codex's review feature)
- * Original source: https://github.com/mitsuhiko/agent-stuff/blob/main/extensions/review.ts
+ * Code Review Extension
  *
  * Provides a `/review-start` command that prompts the agent to review code changes.
  * Supports two review modes:

--- a/extensions/todos/index.ts
+++ b/extensions/todos/index.ts
@@ -1,5 +1,4 @@
 /**
- * Original source: https://github.com/mitsuhiko/agent-stuff/blob/main/extensions/todos.ts
  *
  * This extension stores todo items as files under <todo-dir> (defaults to .pi/todos,
  * or the path in PI_TODO_PATH).  Each todo is a standalone markdown file named

--- a/extensions/uv/index.ts
+++ b/extensions/uv/index.ts
@@ -1,6 +1,5 @@
 /**
  * UV Extension - Redirects Python tooling to uv equivalents
- * Original source: https://github.com/mitsuhiko/agent-stuff/blob/main/extensions/uv.ts
  *
  * This extension wraps the bash tool to prepend uv's intercepted-commands to PATH,
  * which contains shim scripts that intercept common Python tooling commands

--- a/extensions/uv/intercepted-commands/pip
+++ b/extensions/uv/intercepted-commands/pip
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Original source: https://github.com/mitsuhiko/agent-stuff/blob/main/intercepted-commands/pip
 echo "Error: pip is disabled. Use uv instead:" >&2
 echo "" >&2
 echo "  To install a package for a script: uv run --with PACKAGE python script.py" >&2

--- a/extensions/uv/intercepted-commands/pip3
+++ b/extensions/uv/intercepted-commands/pip3
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Original source: https://github.com/mitsuhiko/agent-stuff/blob/main/intercepted-commands/pip3
 echo "Error: pip3 is disabled. Use uv instead:" >&2
 echo "" >&2
 echo "  To install a package for a script: uv run --with PACKAGE python script.py" >&2

--- a/extensions/uv/intercepted-commands/poetry
+++ b/extensions/uv/intercepted-commands/poetry
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Original source: https://github.com/mitsuhiko/agent-stuff/blob/main/intercepted-commands/poetry
 
 echo "Error: poetry is disabled. Use uv instead:" >&2
 echo "" >&2

--- a/extensions/uv/intercepted-commands/python
+++ b/extensions/uv/intercepted-commands/python
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Original source: https://github.com/mitsuhiko/agent-stuff/blob/main/intercepted-commands/python
 
 # Check uv is available before anything else
 if ! command -v uv >/dev/null 2>&1; then

--- a/extensions/uv/intercepted-commands/python3
+++ b/extensions/uv/intercepted-commands/python3
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Original source: https://github.com/mitsuhiko/agent-stuff/blob/main/intercepted-commands/python3
 
 # Check uv is available before anything else
 if ! command -v uv >/dev/null 2>&1; then

--- a/extensions/whimsical/index.ts
+++ b/extensions/whimsical/index.ts
@@ -1,5 +1,4 @@
 /**
- * Original source: https://github.com/mitsuhiko/agent-stuff/blob/main/extensions/whimsical.ts
  */
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { pickRandom } from "./helpers.ts";

--- a/skills/pac-github/SKILL.md
+++ b/skills/pac-github/SKILL.md
@@ -10,8 +10,6 @@ metadata:
 
 # GitHub Skill
 
-<!-- Original source: https://github.com/mitsuhiko/agent-stuff/blob/main/skills/github/SKILL.md -->
-
 Use the `gh` CLI to interact with GitHub. Always specify `--repo owner/repo` when not in a git directory, or use URLs directly.
 
 ## Pull Requests

--- a/skills/pac-librarian/SKILL.md
+++ b/skills/pac-librarian/SKILL.md
@@ -10,8 +10,6 @@ metadata:
 
 # Cache remote repository checkouts
 
-<!-- Original source: https://github.com/mitsuhiko/agent-stuff/blob/main/skills/librarian/SKILL.md -->
-
 Use this skill when the user points you to a remote git repository (GitHub/GitLab/Bitbucket URLs, `git@...`, or `owner/repo` shorthand).
 
 The goal is to keep a reusable local checkout that is:

--- a/skills/pac-librarian/checkout.sh
+++ b/skills/pac-librarian/checkout.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Original source: https://github.com/mitsuhiko/agent-stuff/blob/main/skills/librarian/checkout.sh
 set -euo pipefail
 
 usage() {

--- a/skills/pac-upstream-checkpoints/MODEL.md
+++ b/skills/pac-upstream-checkpoints/MODEL.md
@@ -15,6 +15,7 @@ This model defines the vocabulary for `.pac/upstream-sources.yaml` and `/pac-ups
 - `skill`: one local skill directory under `skills/`.
 - `extension`: one local extension directory under `extensions/`.
 - `prompt`: one local prompt file under `prompts/`.
+- `theme`: one local theme file under `themes/`.
 - `document`: one standalone document with active upstream tracking.
 - `script`: one standalone script with active upstream tracking.
 

--- a/skills/pac-uv/SKILL.md
+++ b/skills/pac-uv/SKILL.md
@@ -10,8 +10,6 @@ metadata:
 
 # Use uv for Python workflows
 
-<!-- Original source: https://github.com/mitsuhiko/agent-stuff/blob/main/skills/uv/SKILL.md -->
-
 ## Quick Reference
 
 ```bash

--- a/skills/pac-uv/build.md
+++ b/skills/pac-uv/build.md
@@ -1,7 +1,5 @@
 # uv Build Backend
 
-<!-- Original source: https://github.com/mitsuhiko/agent-stuff/blob/main/skills/uv/build.md -->
-
 Use `uv_build` for pure Python packages. For extension modules, use `hatchling` instead.
 
 ## pyproject.toml

--- a/skills/pac-uv/scripts.md
+++ b/skills/pac-uv/scripts.md
@@ -1,7 +1,5 @@
 # Running Scripts with uv
 
-<!-- Original source: https://github.com/mitsuhiko/agent-stuff/blob/main/skills/uv/scripts.md -->
-
 ## Basic Usage
 
 ```bash

--- a/themes/gruvbox-dark.json
+++ b/themes/gruvbox-dark.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/badlogic/pi-mono/main/packages/coding-agent/src/modes/interactive/theme/theme-schema.json",
-  "$comment": "Original source: https://github.com/ifiokjr/oh-pi/blob/main/packages/themes/themes/gruvbox-dark.json",
   "name": "gruvbox-dark",
   "vars": {
     "bg0": "#282828", "bg1": "#3c3836", "bg2": "#504945", "bg3": "#665c54",

--- a/themes/nightowl.json
+++ b/themes/nightowl.json
@@ -1,6 +1,5 @@
 {
 	"$schema": "https://raw.githubusercontent.com/badlogic/pi-mono/main/packages/coding-agent/theme-schema.json",
-	"$comment": "Original source: https://github.com/mitsuhiko/agent-stuff/blob/main/themes/nightowl.json",
 	"name": "nightowl",
 	"vars": {
 		"cyan": "#7fdbca",

--- a/themes/nord.json
+++ b/themes/nord.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/badlogic/pi-mono/main/packages/coding-agent/src/modes/interactive/theme/theme-schema.json",
-  "$comment": "Original source: https://github.com/ifiokjr/oh-pi/blob/main/packages/themes/themes/nord.json",
   "name": "nord",
   "vars": {
     "nord0": "#2e3440", "nord1": "#3b4252", "nord2": "#434c5e", "nord3": "#4c566a",


### PR DESCRIPTION
Register theme provenance and UV intercepted-command sources before removing redundant inline source comments.

Verification: npm test; npm run typecheck; JSON/YAML parse checks

closes #263
