### PR TITLE
ladislas/feature/280 feat extension add cost focused session statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioned sections should match the Git tags and GitHub releases published for t
 
 ### Added
 
+- Added cost-focused `/session-breakdown` stats with a compact colorized default report, trend insights, model/directory cost bars, an outlier diagnostic summary, top-5 session/model/directory drill-downs, worktree-aware directory grouping, and cache/context metrics when available. ([#280](https://github.com/ladislas/mypac/issues/280))
 - Added a repo-local Worktrunk extension with `/worktree issue <issue-number-or-url>`, issue-derived branch names, create-or-reuse behavior, Worktrunk `pre-start` setup hooks, and workflow documentation for parallel Pi issue work. ([#85](https://github.com/ladislas/mypac/issues/85))
 - Added non-issue Worktrunk shortcuts for explicit branch worktrees, listing worktrees, and showing current worktree status from Pi. ([#270](https://github.com/ladislas/mypac/issues/270))
 - Added a custom Pi footer extension with write-cache token totals, provider-qualified model labels, context/budget threshold coloring, Codex/Copilot/Claude usage bars, and no default auto-compaction percentage segment. ([#265](https://github.com/ladislas/mypac/issues/265))

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ For readability, the skill table below drops the `pac-` prefix in the display la
 | [`ghi`](extensions/ghi/) | `/ghi` | Creates a GitHub issue in the current repository using `gh` |
 | [`multi-edit`](extensions/multi-edit/) | `edit` tool override | Extends Pi's `edit` tool with batch edits and Codex-style patch support |
 | [`review`](extensions/review/) | `/review-start`, `/review-end` | Reviews uncommitted changes, commits, branches, PRs, or folders from inside Pi |
+| [`session-breakdown`](extensions/session-breakdown/) | `/session-breakdown` | Shows local Pi session usage, cost, model, directory, and cache/context statistics without printing raw transcripts |
 | [`session-names`](extensions/session-names/) | background behavior | Names `/pac-lwot` sessions from the work context you provide |
 | [`shared-append-system`](extensions/shared-append-system/) | background behavior | Injects shared append-system instructions into the session system prompt |
 | [`slidedeck`](extensions/slidedeck/) | `/pac-slidedeck` | Generates a self-contained HTML slidedeck and saves it under `~/.pi/agent/slidedecks/` instead of the repo workspace |

--- a/extensions/session-breakdown/README.md
+++ b/extensions/session-breakdown/README.md
@@ -2,7 +2,9 @@
 
 Registers `/session-breakdown` to summarize local Pi usage from JSONL files under the resolved Pi agent session directory. By default this is `~/.pi/agent/sessions`; `PI_CODING_AGENT_DIR`, `TAU_CODING_AGENT_DIR`, or another `*_CODING_AGENT_DIR` override is honored when set.
 
-The command reports 7, 30, and 90 day aggregates for sessions, messages, tokens, cost, models, and working directories when those fields are present in the session logs.
+The default command output is a compact, colorized report with an overview table, cost insights, model/directory cost bars, an outlier diagnostic summary, and readable top-5 drill-down sections for expensive sessions, model efficiency, directory cost centers, and cache/context metrics when available. Git worktrees are grouped under their canonical repository in directory cost centers. Use `--no-color` to disable ANSI color in the report.
+
+Workflow categories use a lightweight privacy-safe heuristic from session file paths and working directories only: names containing `lwot`, `grill`, `review`, or `triage` map to those categories; names containing implementation-ish words such as `feature`, `bugfix`, `fix`, `commit`, or `implementation` map to `implementation`; everything else is `other`.
 
 Privacy notes:
 

--- a/extensions/session-breakdown/helpers.test.mjs
+++ b/extensions/session-breakdown/helpers.test.mjs
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import {
 	abbreviatePath,
 	analyzeSessionDirectory,
+	formatCompactBreakdownReport,
 	formatBreakdownReport,
 	getDefaultSessionRoot,
 	parseSessionLines,
@@ -17,6 +18,10 @@ const day = (iso) => new Date(iso);
 
 function jsonl(records) {
 	return records.map((record) => (typeof record === "string" ? record : JSON.stringify(record))).join("\n") + "\n";
+}
+
+function stripMarkdownLinks(text) {
+	return text.replace(/\[([^\]]+)\]\([^\)]+\)/g, "$1");
 }
 
 test("parseSessionStartFromFilename reads Pi session filename timestamps", () => {
@@ -92,6 +97,46 @@ test("parseSessionLines uses current model for provider-only messages", () => {
 	assert.ok(parsed);
 	assert.equal(parsed.messagesByModel.get("openai-codex/gpt-5.5"), 1);
 	assert.equal(parsed.messagesByModel.has("openai-codex"), false);
+});
+
+test("analyzeSessionDirectory aggregates session costs and inferred workflow categories", async () => {
+	const root = await mkdtemp(join(tmpdir(), "session-breakdown-"));
+	try {
+		await mkdir(join(root, "--project--"));
+		const sessions = [
+			["2026-05-20T10-00-00-000Z_pac-lwot.jsonl", "/Users/alice/dev/project", "openai-codex", "gpt-5.5", 100, 1],
+			["2026-05-20T11-00-00-000Z_grill-design.jsonl", "/Users/alice/dev/project", "openai-codex", "gpt-5.5", 200, 2],
+			["2026-05-20T12-00-00-000Z_review.jsonl", "/Users/alice/dev/project", "anthropic", "claude", 300, 3],
+			["2026-05-20T13-00-00-000Z_feature-thing.jsonl", "/Users/alice/dev/project", "anthropic", "claude", 400, 4],
+		];
+		for (const [name, cwd, provider, model, totalTokens, totalCost] of sessions) {
+			await writeFile(
+				join(root, "--project--", name),
+				jsonl([
+					{ type: "session", timestamp: "2026-05-20T10:00:00.000Z", cwd },
+					{ type: "message", provider, model, usage: { totalTokens, cost: { total: totalCost } } },
+				]),
+			);
+		}
+
+		const report = await analyzeSessionDirectory({ root, now: day("2026-05-22T12:00:00.000Z") });
+		const range = report.ranges.get(7);
+		assert.ok(range);
+		assert.deepEqual(range.sessionCosts, [1, 2, 3, 4]);
+		assert.equal(range.workflowStats.get("lwot")?.totalCost, 1);
+		assert.equal(range.workflowStats.get("grill")?.totalCost, 2);
+		assert.equal(range.workflowStats.get("review")?.totalCost, 3);
+		assert.equal(range.workflowStats.get("implementation")?.totalCost, 4);
+
+		const text = formatBreakdownReport(report, { homeDir: "/Users/alice" });
+		assert.match(text, /cost distribution: avg\/session \$2\.50 · median \$2\.50 · p90 \$4\.00 · max \$4\.00/);
+		assert.match(text, /top expensive sessions:\n    - 2026-05-20 · .*feature-thing\.jsonl: \$4\.00/);
+		assert.match(text, /cost by workflow type:\n    - implementation: \$4\.00 · avg\/session \$4\.00 · sessions 1 · messages 1 · tokens 400/);
+		assert.match(text, /cost by model:\n    - anthropic\/claude: \$7\.00 · avg\/message \$3\.50 · avg\/session \$3\.50/);
+		assert.match(text, /cost by directory:\n    - ~\/dev\/project: \$10\.00 · avg\/message \$2\.50 · avg\/session \$2\.50/);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
 });
 
 test("analyzeSessionDirectory aggregates 7, 30, and 90 day windows by model and cwd", async () => {
@@ -241,6 +286,593 @@ test("formatBreakdownReport includes model and directory token/cost breakdowns w
 		assert.match(text, /messages by directory:\n    - ~\/dev\/project: 1/);
 		assert.match(text, /tokens by directory:\n    - ~\/dev\/project: 100/);
 		assert.match(text, /cost by directory:\n    - ~\/dev\/project: \$0\.5000/);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("formatCompactBreakdownReport leads with overview, insights, bars, and outliers", async () => {
+	const root = await mkdtemp(join(tmpdir(), "session-breakdown-"));
+	try {
+		await mkdir(join(root, "--project--"));
+		const sessions = [
+			["2026-05-20T10-00-00-000Z_one.jsonl", "/Users/alice/dev/project", "openai-codex", "gpt-5.5", 1_000_000, 10],
+			["2026-05-21T10-00-00-000Z_two.jsonl", "/Users/alice/dev/project", "openai-codex", "gpt-5.5", 500_000, 8],
+			["2026-05-22T10-00-00-000Z_three.jsonl", "/Users/alice/dev/other", "anthropic", "claude", 100_000, 2],
+			["2026-05-01T10-00-00-000Z_four.jsonl", "/Users/alice/dev/older", "anthropic", "claude", 100_000, 1],
+		];
+		for (const [name, cwd, provider, model, totalTokens, totalCost] of sessions) {
+			await writeFile(
+				join(root, "--project--", name),
+				jsonl([
+					{ type: "session", timestamp: "2026-05-20T10:00:00.000Z", cwd },
+					{ type: "message", provider, model, usage: { totalTokens, cost: { total: totalCost } } },
+				]),
+			);
+		}
+
+		const report = await analyzeSessionDirectory({ root, now: day("2026-05-22T12:00:00.000Z") });
+		const text = formatCompactBreakdownReport(report, { homeDir: "/Users/alice", color: false });
+
+		assert.match(text, /Overview/);
+		assert.match(text, /│ 7d\s+│ 3\s+│ 3\s+│ 1\.6M\s+│ \$20\.00\s+│ \$2\.86\s+│/);
+		assert.match(text, /Insights/);
+		assert.match(text, /Current pace projects to ~\$86\/month/);
+		assert.match(text, /🔥 Usage is accelerating: 7d daily cost is 4\.1× the 30d average/);
+		assert.match(text, /🎯 Top 3 sessions account for 100\.0% of 7d cost/);
+		assert.match(text, /📈 Last 7d already represents 95\.2% of 90d spend/);
+		assert.match(text, /Cost by model · 30d spend share/);
+		assert.match(text, /openai-codex\/gpt-5\.5\s+\$18\.00\s+█+/);
+		assert.match(text, /Cost by directory · 30d spend share/);
+		assert.match(text, /~\/dev\/project\s+\$18\.00\s+█+/);
+		assert.match(text, /Outliers · 7d/);
+		assert.match(text, /Most expensive session: \$10\.00 · one · project · project/);
+		assert.match(text, /Top 3 sessions: \$20\.00 · 100\.0% of 7d cost/);
+		assert.match(text, /Main cost center: ~\/dev\/project · 85\.7% of 30d spend/);
+		assert.doesNotMatch(text, /^🔴 \$10\.00\s+2026-05-20/m);
+		assert.doesNotMatch(text, /Use --details for the full breakdown/);
+		assert.doesNotMatch(text, /one\.jsonl/);
+		assert.match(text, /Session drill-down · 7d · top 5 by cost/);
+		assert.match(text, /Model drill-down · 30d · top 5 by cost/);
+		assert.match(text, /Directory drill-down · 30d · top 5 by cost/);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("formatCompactBreakdownReport keeps overview rows aligned for large values", async () => {
+	const report = await analyzeSessionDirectory({ root: join(tmpdir(), `missing-session-breakdown-${Date.now()}`) });
+	const range = report.ranges.get(7);
+	assert.ok(range);
+	range.sessions = 1_234_567_890;
+	range.totalMessages = 9_876_543_210;
+	range.totalTokens = 12_345_678_901_234;
+	range.totalCost = 123_456_789;
+	report.parsedSessions = range.sessions;
+
+	const text = formatCompactBreakdownReport(report, { color: false });
+	const border = text.split("\n").find((line) => line.startsWith("┌"));
+	const row = text.split("\n").find((line) => line.startsWith("│ 7d"));
+
+	assert.ok(border);
+	assert.ok(row);
+	assert.equal(row.length, border.length);
+	assert.match(row, /…/);
+});
+
+test("formatBreakdownReport computes cost distribution without spreading large arrays", async () => {
+	const report = await analyzeSessionDirectory({ root: join(tmpdir(), `missing-session-breakdown-${Date.now()}`) });
+	const range = report.ranges.get(7);
+	assert.ok(range);
+	range.sessions = 200_000;
+	range.sessionCosts = Array.from({ length: range.sessions }, (_, index) => index % 1000);
+	report.scannedFiles = range.sessions;
+	report.parsedSessions = range.sessions;
+
+	const text = formatBreakdownReport(report);
+	assert.match(text, /cost distribution: avg\/session \$499\.50 · median \$499\.50 · p90 \$899\.00 · max \$999\.00/);
+});
+
+test("formatCompactBreakdownReport adds readable drill-down sections below the dashboard", async () => {
+	const root = await mkdtemp(join(tmpdir(), "session-breakdown-"));
+	try {
+		const rows = [
+			["2026-05-20T10-00-00-000Z_019e50ce-6073-787c-b2c6-81913fb09d05.jsonl", "/Users/alice/dev/ladislas/mypac", "openai-codex", "gpt-5.5", 120, 18_400_000, 16.92, "ladislas/mypac lwot - issue #279"],
+			["2026-05-21T10-00-00-000Z_019e4ad9-1111-2222-3333-444444b3d00c.jsonl", "/Users/alice/dev/ladislas/mypac", "openai-codex", "gpt-5.5", 80, 13_100_000, 13.82, "ladislas/mypac lwot - issue #265"],
+			["2026-05-22T10-00-00-000Z_019e459d-1111-2222-3333-4444447fc1d9.jsonl", "/Users/alice/dev/other", "opencode-go", "glm-5.1", 30, 10_900_000, 5.84, "Other implementation"],
+		];
+		for (const [name, cwd, provider, model, messages, tokens, cost, title] of rows) {
+			const perMessageTokens = Math.floor(tokens / messages);
+			const perMessageCost = cost / messages;
+			await writeFile(
+				join(root, name),
+				jsonl([
+					{ type: "session", timestamp: name.replace(/_(.+)\.jsonl$/, "Z").replace(/T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z$/, "T$1:$2:$3.$4Z"), cwd },
+					{ type: "session_info", name: title },
+					...Array.from({ length: messages }, () => ({ type: "message", provider, model, usage: { totalTokens: perMessageTokens, cost: { total: perMessageCost } } })),
+				]),
+			);
+		}
+
+		const report = await analyzeSessionDirectory({ root, now: day("2026-05-22T12:00:00.000Z") });
+		const text = stripMarkdownLinks(formatCompactBreakdownReport(report, { homeDir: "/Users/alice", color: false }));
+
+		assert.match(text, /Session drill-down · 7d · top 5 by cost\nCost\s+Date\s+ID\s+Msgs\s+Tokens\s+Main model\s+Title/);
+		assert.match(text, /\$16\.92\s+2026-05-20\s+019e50ce…b09d05\s+120\s+18\.4M\s+gpt-5\.5\s+mypac · lwot - issue #279/);
+		assert.match(text, /Model drill-down · 30d · top 5 by cost\nModel\s+Sessions\s+Msgs\s+Tokens\s+Cost\s+\$\/msg\s+\$\/1M tok/);
+		assert.match(text, /openai-codex\/gpt-5\.5\s+2\s+200\s+31\.5M\s+\$30\.74\s+\$0\.1537\s+\$0\.98/);
+		assert.match(text, /Directory drill-down · 30d · top 5 by cost\nDirectory\s+Sessions\s+Msgs\s+Tokens\s+Cost\s+Avg\/session/);
+		assert.match(text, /~\/dev\/ladislas\/mypac\s+2\s+200\s+31\.5M\s+\$30\.74\s+\$15\.37/);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("formatCompactBreakdownReport renders directory average session costs with two decimals", async () => {
+	const root = await mkdtemp(join(tmpdir(), "session-breakdown-"));
+	try {
+		const rows = [
+			["2026-05-20T10-00-00-000Z_one.jsonl", "/Users/alice/dev/project", 0.5045],
+			["2026-05-21T10-00-00-000Z_two.jsonl", "/Users/alice/dev/project", 0.5045],
+			["2026-05-22T10-00-00-000Z_three.jsonl", "/Users/alice/dev/other", 0.5882],
+		];
+		for (const [name, cwd, totalCost] of rows) {
+			await writeFile(
+				join(root, name),
+				jsonl([
+					{ type: "session", timestamp: "2026-05-20T10:00:00.000Z", cwd },
+					{ type: "message", provider: "openai-codex", model: "gpt-5.5", usage: { totalTokens: 100, cost: { total: totalCost } } },
+				]),
+			);
+		}
+
+		const report = await analyzeSessionDirectory({ root, now: day("2026-05-22T12:00:00.000Z") });
+		const text = formatCompactBreakdownReport(report, { homeDir: "/Users/alice", color: false });
+		const directorySection = text.slice(text.indexOf("Directory drill-down"));
+
+		assert.match(directorySection, /~\/dev\/project\s+2\s+2\s+200\s+\$1\.01\s+\$0\.50/);
+		assert.match(directorySection, /~\/dev\/other\s+1\s+1\s+100\s+\$0\.5882\s+\$0\.59/);
+		assert.doesNotMatch(directorySection, /\$0\.5045/);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("formatCompactBreakdownReport truncates drill-down rows to one terminal line", async () => {
+	const root = await mkdtemp(join(tmpdir(), "session-breakdown-"));
+	try {
+		await writeFile(
+			join(root, "2026-05-20T10-00-00-000Z_019e50ce-6073-787c-b2c6-81913fb09d05.jsonl"),
+			jsonl([
+				{ type: "session", id: "019e50ce-6073-787c-b2c6-81913fb09d05", timestamp: "2026-05-20T10:00:00.000Z", cwd: "/Users/alice/dev/worktrees/ladislas/mypac/ladislas-feature-237-investigate-agent-stuff-session-breakdown-extension-for-usage-stats" },
+				{ type: "session_info", name: "This is a very long compact session breakdown title that should not wrap in a normal terminal" },
+				{ type: "message", provider: "openai-codex-with-a-very-long-provider-name", model: "gpt-5.5-ultra-long-model-name", usage: { totalTokens: 25_700_000, cost: { total: 22.76 } } },
+			]),
+		);
+
+		const report = await analyzeSessionDirectory({ root, now: day("2026-05-22T12:00:00.000Z") });
+		const text = formatCompactBreakdownReport(report, { homeDir: "/Users/alice", color: false });
+		const sessionRow = text.split("\n").find((line) => line.includes("019e50ce…b09d05") && line.includes("$22.76"));
+		const directoryRow = text.split("\n").find((line) => line.startsWith("~/dev/ladislas/mypac") && line.includes("$22.76"));
+
+		assert.ok(sessionRow);
+		assert.ok(sessionRow.length <= 120, `session row should stay one line: ${sessionRow.length}`);
+		assert.match(sessionRow, /…/);
+		assert.ok(directoryRow);
+		assert.ok(directoryRow.length <= 120, `directory row should stay one line: ${directoryRow.length}`);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("formatCompactBreakdownReport includes cache and context metrics when available", async () => {
+	const root = await mkdtemp(join(tmpdir(), "session-breakdown-"));
+	try {
+		await writeFile(
+			join(root, "2026-05-20T10-00-00-000Z_019e50ce-6073-787c-b2c6-81913fb09d05.jsonl"),
+			jsonl([
+				{ type: "session", timestamp: "2026-05-20T10:00:00.000Z", cwd: "/Users/alice/dev/project" },
+				{ type: "message", provider: "openai-codex", model: "gpt-5.5", usage: { inputTokens: 1000, outputTokens: 500, cacheReadTokens: 21_000_000, cacheWriteTokens: 1_000_000, contextTokens: 100_000, maxContextTokens: 200_000, cost: { total: 1 } } },
+				{ type: "message", provider: "openai-codex", model: "gpt-5.5", usage: { inputTokens: 1000, outputTokens: 250, cacheReadTokens: 42_000_000, cacheWriteTokens: 2_000_000, contextTokens: 140_000, maxContextTokens: 240_000, cost: { total: 1 } } },
+			]),
+		);
+
+		const report = await analyzeSessionDirectory({ root, now: day("2026-05-22T12:00:00.000Z") });
+		const text = formatCompactBreakdownReport(report, { homeDir: "/Users/alice", color: false });
+
+		assert.match(text, /Cache \/ context · 7d/);
+		assert.match(text, /Cache read\/write\s+63\.0M \/ 3\.0M tokens/);
+		assert.match(text, /Cache leverage\s+21\.0× read per write/);
+		assert.match(text, /Avg context\s+120\.0k \/ 240\.0k/);
+		assert.match(text, /Context pressure\s+50%/);
+		assert.match(text, /Input\/output\s+2\.7×/);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("formatCompactBreakdownReport classifies cache health thresholds", async () => {
+	const cases = [
+		[50, "excellent reuse"],
+		[10, "good reuse"],
+		[3, "moderate reuse"],
+		[2, "low reuse"],
+	];
+	for (const [leverage, label] of cases) {
+		const root = await mkdtemp(join(tmpdir(), "session-breakdown-cache-"));
+		try {
+			await writeFile(
+				join(root, "2026-05-20T10-00-00-000Z_019e50ce-6073-787c-b2c6-81913fb09d05.jsonl"),
+				jsonl([
+					{ type: "session", timestamp: "2026-05-20T10:00:00.000Z", cwd: "/Users/alice/dev/project" },
+					{ type: "message", provider: "openai-codex", model: "gpt-5.5", usage: { cacheReadTokens: leverage * 1000, cacheWriteTokens: 1000, cost: { total: 1 } } },
+				]),
+			);
+			const report = await analyzeSessionDirectory({ root, now: day("2026-05-22T12:00:00.000Z") });
+			const text = formatCompactBreakdownReport(report, { homeDir: "/Users/alice", color: false });
+			assert.match(text, new RegExp(`Cache health\\s+${label}`));
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	}
+});
+
+test("formatCompactBreakdownReport groups git worktrees under the canonical repo directory", async () => {
+	const root = await mkdtemp(join(tmpdir(), "session-breakdown-worktree-"));
+	try {
+		const mainRepo = join(root, "dev/ladislas/mypac");
+		const worktree = join(root, "dev/worktrees/ladislas/mypac/feature-280-focused-session-statistics");
+		const worktreeGitDir = join(mainRepo, ".git/worktrees/feature-280-focused-session-statistics");
+		await mkdir(worktreeGitDir, { recursive: true });
+		await mkdir(worktree, { recursive: true });
+		await writeFile(join(worktree, ".git"), `gitdir: ${worktreeGitDir}\n`);
+		await writeFile(join(worktreeGitDir, "commondir"), "../..\n");
+
+		await writeFile(
+			join(root, "2026-05-20T10-00-00-000Z_019e50ce-6073-787c-b2c6-81913fb09d05.jsonl"),
+			jsonl([
+				{ type: "session", id: "019e50ce-6073-787c-b2c6-81913fb09d05", timestamp: "2026-05-20T10:00:00.000Z", cwd: worktree },
+				{ type: "session_info", name: "feature worktree session" },
+				{ type: "message", provider: "openai-codex", model: "gpt-5.5", usage: { totalTokens: 1000, cost: { total: 10 } } },
+			]),
+		);
+		await writeFile(
+			join(root, "2026-05-21T10-00-00-000Z_019e4ad9-1111-2222-3333-444444b3d00c.jsonl"),
+			jsonl([
+				{ type: "session", timestamp: "2026-05-21T10:00:00.000Z", cwd: mainRepo },
+				{ type: "message", provider: "openai-codex", model: "gpt-5.5", usage: { totalTokens: 2000, cost: { total: 5 } } },
+			]),
+		);
+
+		const report = await analyzeSessionDirectory({ root, now: day("2026-05-22T12:00:00.000Z") });
+		const text = formatCompactBreakdownReport(report, { homeDir: root, color: false });
+		const directoryRow = text.split("\n").find((line) => line.startsWith("~/dev/ladislas/mypac") && line.includes("$7.50"));
+		const sessionRow = text.split("\n").find((line) => line.includes("019e50ce…b09d05"));
+
+		assert.match(directoryRow ?? "", /^~\/dev\/ladislas\/mypac\s+2\s+2\s+3,000\s+\$15\.00\s+\$7\.50/);
+		assert.doesNotMatch(text, /feature-280-focused-session-statistics\s+2\s+2\s+3,000/);
+		assert.match(sessionRow ?? "", /feature worktree session/);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("formatCompactBreakdownReport groups historical worktree paths even when the worktree no longer exists", async () => {
+	const root = await mkdtemp(join(tmpdir(), "session-breakdown-missing-worktree-"));
+	try {
+		const missingWorktree = "/Users/alice/dev/worktrees/ladislas/mypac/feature-237-session-breakdown-extension";
+		await writeFile(
+			join(root, "2026-05-20T10-00-00-000Z_019e50ce-6073-787c-b2c6-81913fb09d05.jsonl"),
+			jsonl([
+				{ type: "session", timestamp: "2026-05-20T10:00:00.000Z", cwd: missingWorktree },
+				{ type: "message", provider: "openai-codex", model: "gpt-5.5", usage: { totalTokens: 25_700_000, cost: { total: 22.76 } } },
+			]),
+		);
+
+		const report = await analyzeSessionDirectory({ root, now: day("2026-05-22T12:00:00.000Z") });
+		const text = formatCompactBreakdownReport(report, { homeDir: "/Users/alice", color: false });
+
+		assert.match(text, /~\/dev\/ladislas\/mypac\s+1\s+1\s+25\.7M\s+\$22\.76\s+\$22\.76/);
+		assert.doesNotMatch(text, /feature-237-session-breakdown-extension\s+1\s+1\s+25\.7M\s+\$22\.76\s+\$22\.76/);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("formatCompactBreakdownReport truncates long spend-share labels so rows do not wrap", async () => {
+	const root = await mkdtemp(join(tmpdir(), "session-breakdown-"));
+	try {
+		await writeFile(
+			join(root, "2026-05-20T10-00-00-000Z_019e50ce-6073-787c-b2c6-81913fb09d05.jsonl"),
+			jsonl([
+				{
+					type: "session",
+					timestamp: "2026-05-20T10:00:00.000Z",
+					cwd: "/Users/alice/dev/worktrees/ladislas/mypac/ladislas-feature-237-investigate-agent-stuff-session-breakdown-extension-for-usage-stats",
+				},
+				{ type: "message", provider: "openai-codex", model: "gpt-5.5", usage: { totalTokens: 100, cost: { total: 22.76 } } },
+			]),
+		);
+
+		const report = await analyzeSessionDirectory({ root, now: day("2026-05-22T12:00:00.000Z") });
+		const text = formatCompactBreakdownReport(report, { homeDir: "/Users/alice", color: false });
+		const row = text.split("\n").find((line) => line.startsWith("~/dev/ladislas/mypac"));
+
+		assert.ok(row);
+		assert.match(row, /^~\/dev\/ladislas\/mypac\s+\$22\.76\s+█+\s+100\.0%$/);
+		assert.ok(row.length <= 100, `row should stay compact: ${row.length}`);
+		assert.doesNotMatch(text, /ladislas-feature-237-investigate/);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("formatCompactBreakdownReport renders identifiable outliers without full JSONL paths", async () => {
+	const root = await mkdtemp(join(tmpdir(), "session-breakdown-"));
+	try {
+		const longTitle = "This is an extremely long session title that should be truncated before it wraps in compact mode";
+		await writeFile(
+			join(root, "2026-05-20T10-00-00-000Z_019e50ce-6073-787c-b2c6-81913fb09d05.jsonl"),
+			jsonl([
+				{ type: "session", id: "019e50ce-6073-787c-b2c6-81913fb09d05", timestamp: "2026-05-20T10:00:00.000Z", cwd: "/Users/alice/dev/project" },
+				{ type: "session_info", name: "Add compact cost report" },
+				{ type: "message", provider: "openai-codex", model: "gpt-5.5", usage: { totalTokens: 100, cost: { total: 16.92 } } },
+			]),
+		);
+		await writeFile(
+			join(root, "2026-05-21T10-00-00-000Z_019e4ad9-1111-2222-3333-4444443d00c.jsonl"),
+			jsonl([
+				{ type: "session", timestamp: "2026-05-21T10:00:00.000Z", cwd: "/Users/alice/dev/project" },
+				{ type: "message", message: { role: "user", content: "Footer token budget indicators" } },
+				{ type: "message", provider: "openai-codex", model: "gpt-5.5", usage: { totalTokens: 100, cost: { total: 13.82 } } },
+			]),
+		);
+		await writeFile(
+			join(root, "2026-05-22T10-00-00-000Z_019e459d-1111-2222-3333-444444fc1d9.jsonl"),
+			jsonl([
+				{ type: "session", timestamp: "2026-05-22T10:00:00.000Z", cwd: "/Users/alice/dev/project" },
+				{ type: "session_info", name: longTitle },
+				{ type: "message", provider: "openai-codex", model: "gpt-5.5", usage: { totalTokens: 100, cost: { total: 12.28 } } },
+			]),
+		);
+
+		const report = await analyzeSessionDirectory({ root, now: day("2026-05-22T12:00:00.000Z") });
+		const text = formatCompactBreakdownReport(report, { homeDir: "/Users/alice", color: false });
+		const outlierLines = [
+			text.split("\n").find((line) => line.includes("Most expensive session")) ?? "",
+			text.split("\n").find((line) => line.includes("Top 3 sessions:")) ?? "",
+			text.split("\n").find((line) => line.includes("Main cost center")) ?? "",
+		];
+		const sessionRows = text.split("\n").filter((line) => line.startsWith("$") && line.includes("019e"));
+
+		assert.match(outlierLines[0], /Most expensive session: \$16\.92 · 019e50ce…b09d05 · project · Add compact cost report/);
+		assert.match(outlierLines[1], /Top 3 sessions: \$43\.02 · 100\.0% of 7d cost/);
+		assert.match(outlierLines[2], /Main cost center: ~\/dev\/project · 100\.0% of 30d spend/);
+		assert.doesNotMatch(text, /^🔴 \$16\.92\s+2026-05-20/m);
+		assert.match(sessionRows[2], /\$12\.28\s+2026-05-22\s+019e459d…4fc1d9\s+1\s+100\s+gpt-5\.5\s+project · This is an extremely long…/);
+		assert.ok(sessionRows.every((line) => line.length <= 120));
+		assert.doesNotMatch(text, /\.jsonl/);
+		assert.doesNotMatch(text, /\/Users\/alice\/dev\/project/);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("formatCompactBreakdownReport summarizes GitHub issue URLs in outlier titles", async () => {
+	const root = await mkdtemp(join(tmpdir(), "session-breakdown-"));
+	try {
+		await writeFile(
+			join(root, "2026-05-20T10-00-00-000Z_019e50ce-6073-787c-b2c6-81913fb09d05.jsonl"),
+			jsonl([
+				{ type: "session", timestamp: "2026-05-20T10:00:00.000Z", cwd: "/Users/alice/dev/project" },
+				{ type: "message", message: { role: "user", content: "lwot - https://github.com/ladislas/mypac/issues/280" } },
+				{ type: "message", provider: "openai-codex", model: "gpt-5.5", usage: { totalTokens: 100, cost: { total: 16.92 } } },
+			]),
+		);
+		await writeFile(
+			join(root, "2026-05-21T10-00-00-000Z_019e4ad9-1111-2222-3333-444444b3d00c.jsonl"),
+			jsonl([
+				{ type: "session", timestamp: "2026-05-21T10:00:00.000Z", cwd: "/Users/alice/dev/project" },
+				{ type: "message", message: { role: "user", content: "issue #265: Footer token budget indicators" } },
+				{ type: "message", provider: "openai-codex", model: "gpt-5.5", usage: { totalTokens: 100, cost: { total: 13.82 } } },
+			]),
+		);
+
+		const report = await analyzeSessionDirectory({ root, now: day("2026-05-22T12:00:00.000Z") });
+		const text = formatCompactBreakdownReport(report, { homeDir: "/Users/alice", color: false });
+		const outlierLine = text.split("\n").find((line) => line.includes("Most expensive session"));
+		const sessionRows = text.split("\n").filter((line) => line.startsWith("$") && line.includes("019e"));
+
+		assert.equal(stripMarkdownLinks(outlierLine ?? ""), " 🔴 Most expensive session: $16.92 · 019e50ce…b09d05 · project · lwot - issue #280");
+		assert.match(outlierLine ?? "", /\[issue #280\]\(https:\/\/github\.com\/ladislas\/mypac\/issues\/280\)/);
+		assert.match(stripMarkdownLinks(sessionRows[0] ?? ""), /^\$16\.92\s+2026-05-20\s+019e50ce…b09d05\s+2\s+100\s+gpt-5\.5\s+project · lwot - issue #280$/);
+		assert.match(sessionRows[0] ?? "", /\[issue #280\]\(https:\/\/github\.com\/ladislas\/mypac\/issues\/280\)/);
+		assert.match(stripMarkdownLinks(sessionRows[1] ?? ""), /^\$13\.82\s+2026-05-21\s+019e4ad9…b3d00c\s+2\s+100\s+gpt-5\.5\s+project · issue #265 - Footer token…$/);
+		assert.ok(sessionRows.every((line) => !line.includes(".jsonl")));
+		assert.ok(sessionRows.every((line) => !/github\.com\/ladislas\/mypac\/issues\/\d+\s+-/.test(line)));
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("parseSessionLines cleans compact fallback titles from GitHub issue URLs", () => {
+	const cases = [
+		["github.com/ladislas/mypac/issues/279", "issue #279"],
+		["github.com/ladislas/mypac/issues/279%20-%20compact%20session%20breakdown", "issue #279"],
+		["https://github.com/ladislas/mypac/issues/279 - compact session breakdown", "issue #279"],
+		["github.com/ladislas/mypac/issues/279%20-%20Add%20compact%20cost%20report", "issue #279"],
+		["lwot - github.com/ladislas/mypac/issues/279%20-%20-%20additional%20notes", "lwot - issue #279"],
+		["lwot - github.com/ladislas/mypac/issues/279%20-%20Add%20compact%20cost%20report", "lwot - issue #279"],
+		["lwot - github.com/ladislas/mypac/issues/279%ZZ", "lwot - issue #279"],
+		["lwot - issue #265", "lwot - issue #265"],
+	];
+
+	for (const [input, expected] of cases) {
+		const parsed = parseSessionLines(
+			jsonl([
+				{ type: "session", timestamp: "2026-05-20T10:00:00.000Z", cwd: "/Users/alice/dev/project" },
+				{ type: "message", message: { role: "user", content: input } },
+			]),
+			"2026-05-20T10-00-00-000Z_019e50ce-6073-787c-b2c6-81913fb09d05.jsonl",
+		);
+		assert.equal(stripMarkdownLinks(parsed?.title ?? ""), expected);
+		assert.doesNotMatch(parsed?.title ?? "", /github\.com\/ladislas\/mypac\/issues\/279(?:%|\s|-)/);
+	}
+});
+
+test("parseSessionLines cleans explicit session titles from GitHub issue URLs", () => {
+	const parsed = parseSessionLines(
+		jsonl([
+			{ type: "session", timestamp: "2026-05-20T10:00:00.000Z", cwd: "/Users/alice/dev/project" },
+			{ type: "session_info", name: "lwot - github.com/ladislas/mypac/issues/279%20-%20Add%20compact%20cost%20report" },
+		]),
+		"2026-05-20T10-00-00-000Z_019e50ce-6073-787c-b2c6-81913fb09d05.jsonl",
+	);
+
+	assert.equal(stripMarkdownLinks(parsed?.title ?? ""), "lwot - issue #279");
+	assert.doesNotMatch(parsed?.title ?? "", /github\.com\/ladislas\/mypac\/issues\/279(?:%|\s|-)/);
+});
+
+test("parseSessionLines links bare issue refs using inferred cwd repo", () => {
+	const parsed = parseSessionLines(
+		jsonl([
+			{ type: "session", timestamp: "2026-05-20T10:00:00.000Z", cwd: "/Users/alice/dev/worktrees/ladislas/mypac/feature-thing" },
+			{ type: "session_info", name: "lwot - issue #265" },
+		]),
+		"2026-05-20T10-00-00-000Z_019e50ce-6073-787c-b2c6-81913fb09d05.jsonl",
+	);
+
+	assert.equal(stripMarkdownLinks(parsed?.title ?? ""), "lwot - issue #265");
+	assert.match(parsed?.title ?? "", /\[issue #265\]\(https:\/\/github\.com\/ladislas\/mypac\/issues\/265\)/);
+});
+
+test("parseSessionLines does not infer GitHub repos from flat dev project subdirectories", () => {
+	const parsed = parseSessionLines(
+		jsonl([
+			{ type: "session", timestamp: "2026-05-20T10:00:00.000Z", cwd: "/Users/alice/dev/project/src" },
+			{ type: "session_info", name: "issue #280" },
+		]),
+		"2026-05-20T10-00-00-000Z_019e50ce-6073-787c-b2c6-81913fb09d05.jsonl",
+	);
+
+	assert.equal(parsed?.title, "issue #280");
+	assert.doesNotMatch(parsed?.title ?? "", /github\.com\/project\/src\/issues\/280/);
+});
+
+test("parseSessionLines can infer GitHub repos from owner-matching home dev paths", () => {
+	const parsed = parseSessionLines(
+		jsonl([
+			{ type: "session", timestamp: "2026-05-20T10:00:00.000Z", cwd: "/Users/alice/dev/alice/project" },
+			{ type: "session_info", name: "issue #280" },
+		]),
+		"2026-05-20T10-00-00-000Z_019e50ce-6073-787c-b2c6-81913fb09d05.jsonl",
+	);
+
+	assert.match(parsed?.title ?? "", /\[issue #280\]\(https:\/\/github\.com\/alice\/project\/issues\/280\)/);
+});
+
+test("formatCompactBreakdownReport classifies workflow from session filename, not cwd", async () => {
+	const root = await mkdtemp(join(tmpdir(), "session-breakdown-workflow-"));
+	try {
+		await writeFile(
+			join(root, "2026-05-20T10-00-00-000Z_feature-thing.jsonl"),
+			jsonl([
+				{ type: "session", timestamp: "2026-05-20T10:00:00.000Z", cwd: "/Users/alice/dev/code-review-tool" },
+				{ type: "message", provider: "openai-codex", model: "gpt-5.5", usage: { totalTokens: 100, cost: { total: 1 } } },
+			]),
+		);
+
+		const report = await analyzeSessionDirectory({ root, now: day("2026-05-22T12:00:00.000Z") });
+		const range = report.ranges.get(7);
+		assert.equal(range?.workflowStats.get("implementation")?.totalCost, 1);
+		assert.equal(range?.workflowStats.has("review"), false);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("formatCompactBreakdownReport does not classify preview filenames as review", async () => {
+	const root = await mkdtemp(join(tmpdir(), "session-breakdown-workflow-"));
+	try {
+		await writeFile(
+			join(root, "2026-05-20T10-00-00-000Z_preview-report.jsonl"),
+			jsonl([
+				{ type: "session", timestamp: "2026-05-20T10:00:00.000Z", cwd: "/Users/alice/dev/project" },
+				{ type: "message", provider: "openai-codex", model: "gpt-5.5", usage: { totalTokens: 100, cost: { total: 1 } } },
+			]),
+		);
+
+		const report = await analyzeSessionDirectory({ root, now: day("2026-05-22T12:00:00.000Z") });
+		const range = report.ranges.get(7);
+		assert.equal(range?.workflowStats.get("other")?.totalCost, 1);
+		assert.equal(range?.workflowStats.has("review"), false);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("formatCompactBreakdownReport does not truncate inside markdown issue links", async () => {
+	const root = await mkdtemp(join(tmpdir(), "session-breakdown-markdown-"));
+	try {
+		await writeFile(
+			join(root, "2026-05-20T10-00-00-000Z_019e50ce-6073-787c-b2c6-81913fb09d05.jsonl"),
+			jsonl([
+				{ type: "session", timestamp: "2026-05-20T10:00:00.000Z", cwd: "/Users/alice/dev/worktrees/ladislas/mypac/feature-thing" },
+				{ type: "session_info", name: "A compact report title with issue #280: additional details that force truncation" },
+				{ type: "message", provider: "openai-codex", model: "gpt-5.5", usage: { totalTokens: 100, cost: { total: 1 } } },
+			]),
+		);
+
+		const report = await analyzeSessionDirectory({ root, now: day("2026-05-22T12:00:00.000Z") });
+		const text = formatCompactBreakdownReport(report, { homeDir: "/Users/alice", color: false });
+		const row = text.split("\n").find((line) => line.startsWith("$1.00") && line.includes("019e50ce…b09d05"));
+
+		assert.ok(row);
+		assert.doesNotMatch(row, /\[issue #280\]\(https:\/\/github\.com\/ladislas\/mypac\/issues\/280…/);
+		assert.doesNotMatch(row, /github\.com\/ladislas\/mypac\/issues\/280[^)]*…/);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("formatCompactBreakdownReport displays inferred repo for outliers", async () => {
+	const root = await mkdtemp(join(tmpdir(), "session-breakdown-"));
+	try {
+		await writeFile(
+			join(root, "2026-05-20T10-00-00-000Z_019e50ce-6073-787c-b2c6-81913fb09d05.jsonl"),
+			jsonl([
+				{ type: "session", timestamp: "2026-05-20T10:00:00.000Z", cwd: "/Users/alice/dev/worktrees/ladislas/mypac/feature-thing" },
+				{ type: "message", message: { role: "user", content: "lwot - issue #265" } },
+				{ type: "message", provider: "openai-codex", model: "gpt-5.5", usage: { totalTokens: 100, cost: { total: 13.82 } } },
+			]),
+		);
+
+		const report = await analyzeSessionDirectory({ root, now: day("2026-05-22T12:00:00.000Z") });
+		const text = formatCompactBreakdownReport(report, { homeDir: "/Users/alice", color: false });
+		const row = text.split("\n").find((line) => line.startsWith("$13.82") && line.includes("019e50ce…b09d05"));
+
+		assert.match(stripMarkdownLinks(row ?? ""), /^\$13\.82\s+2026-05-20\s+019e50ce…b09d05\s+2\s+100\s+gpt-5\.5\s+mypac · lwot - issue #265$/);
+		assert.match(row ?? "", /\[issue #265\]\(https:\/\/github\.com\/ladislas\/mypac\/issues\/265\)/);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("formatCompactBreakdownReport can emit semantic ANSI color", async () => {
+	const root = await mkdtemp(join(tmpdir(), "session-breakdown-"));
+	try {
+		await writeFile(
+			join(root, "2026-05-20T10-00-00-000Z_019e50ce-6073-787c-b2c6-81913fb09d05.jsonl"),
+			jsonl([
+				{ type: "session", timestamp: "2026-05-20T10:00:00.000Z", cwd: "/Users/alice/dev/project" },
+				{ type: "message", provider: "openai-codex", model: "gpt-5.5", usage: { totalTokens: 100, cost: { total: 1 } } },
+			]),
+		);
+		const report = await analyzeSessionDirectory({ root, now: day("2026-05-22T12:00:00.000Z") });
+		const text = formatCompactBreakdownReport(report, { color: true });
+		assert.match(text, /\u001b\[1mPi session breakdown\u001b\[22m/);
+		assert.match(text, /\u001b\[36m█+/);
+		assert.match(text, /\u001b\[31m🔴\u001b\[39m/);
 	} finally {
 		await rm(root, { recursive: true, force: true });
 	}

--- a/extensions/session-breakdown/helpers.ts
+++ b/extensions/session-breakdown/helpers.ts
@@ -1,7 +1,7 @@
 import { createReadStream } from "node:fs";
-import { readdir, stat } from "node:fs/promises";
+import { readFile, readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, join } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { getSessionRoot } from "../../lib/agent-dir.ts";
 
@@ -13,16 +13,47 @@ type CwdKey = string;
 
 export interface ParsedSession {
 	filePath: string;
+	sessionId: string | null;
+	title: string | null;
+	repo: string | null;
 	startedAt: Date;
 	dayKey: string;
 	cwd: CwdKey | null;
+	cwdGroup: CwdKey | null;
 	modelsUsed: Set<ModelKey>;
 	messages: number;
 	tokens: number;
 	totalCost: number;
+	cacheReadTokens: number;
+	cacheWriteTokens: number;
+	inputTokens: number;
+	outputTokens: number;
+	contextTokensTotal: number;
+	contextSamples: number;
+	maxContextTokens: number;
 	messagesByModel: Map<ModelKey, number>;
 	tokensByModel: Map<ModelKey, number>;
 	costByModel: Map<ModelKey, number>;
+}
+
+export interface CostSessionSummary {
+	filePath: string;
+	sessionId: string | null;
+	title: string | null;
+	repo: string | null;
+	cwd: string | null;
+	startedAt: Date;
+	totalCost: number;
+	messages: number;
+	tokens: number;
+	mainModel: string | null;
+}
+
+export interface WorkflowAggregate {
+	sessions: number;
+	messages: number;
+	tokens: number;
+	totalCost: number;
 }
 
 export interface DayAggregate {
@@ -49,6 +80,16 @@ export interface RangeAggregate {
 	cwdMessages: Map<CwdKey, number>;
 	cwdTokens: Map<CwdKey, number>;
 	cwdCost: Map<CwdKey, number>;
+	sessionCosts: number[];
+	topCostSessions: CostSessionSummary[];
+	workflowStats: Map<string, WorkflowAggregate>;
+	cacheReadTokens: number;
+	cacheWriteTokens: number;
+	inputTokens: number;
+	outputTokens: number;
+	contextTokensTotal: number;
+	contextSamples: number;
+	maxContextTokens: number;
 }
 
 export interface SessionBreakdownReport {
@@ -75,12 +116,23 @@ export function getDefaultSessionRoot(env: NodeJS.ProcessEnv = process.env, home
 
 interface SessionParseState {
 	filePath: string;
+	sessionId: string | null;
+	title: string | null;
+	repo: string | null;
+	firstUserText: string | null;
 	startedAt: Date | null;
 	cwd: string | null;
 	currentModel: string | null;
 	messages: number;
 	tokens: number;
 	totalCost: number;
+	cacheReadTokens: number;
+	cacheWriteTokens: number;
+	inputTokens: number;
+	outputTokens: number;
+	contextTokensTotal: number;
+	contextSamples: number;
+	maxContextTokens: number;
 	skippedLines: number;
 	modelsUsed: Set<string>;
 	messagesByModel: Map<string, number>;
@@ -100,6 +152,27 @@ function readNumber(value: unknown): number {
 function addToMap<K>(map: Map<K, number>, key: K, value: number): void {
 	if (value === 0) return;
 	map.set(key, (map.get(key) ?? 0) + value);
+}
+
+function addToWorkflowMap(map: Map<string, WorkflowAggregate>, key: string, session: ParsedSession): void {
+	const current = map.get(key) ?? { sessions: 0, messages: 0, tokens: 0, totalCost: 0 };
+	current.sessions += 1;
+	current.messages += session.messages;
+	current.tokens += session.tokens;
+	current.totalCost += session.totalCost;
+	map.set(key, current);
+}
+
+function getMainModel(session: ParsedSession): string | null {
+	const ranked = [...session.modelsUsed].sort((a, b) => {
+		const costDelta = (session.costByModel.get(b) ?? 0) - (session.costByModel.get(a) ?? 0);
+		if (costDelta !== 0) return costDelta;
+		const tokenDelta = (session.tokensByModel.get(b) ?? 0) - (session.tokensByModel.get(a) ?? 0);
+		if (tokenDelta !== 0) return tokenDelta;
+		const messageDelta = (session.messagesByModel.get(b) ?? 0) - (session.messagesByModel.get(a) ?? 0);
+		return messageDelta || a.localeCompare(b);
+	});
+	return ranked[0] ?? null;
 }
 
 function toDayKey(date: Date): string {
@@ -174,8 +247,38 @@ function extractTokens(usage: any): number {
 		readNumber(usage.outputTokens) ||
 		readNumber(usage.output_tokens) ||
 		readNumber(usage.output);
-	const cache = readNumber(usage.cacheRead) + readNumber(usage.cache_read) + readNumber(usage.cacheWrite) + readNumber(usage.cache_write);
+	const cache = extractCacheReadTokens(usage) + extractCacheWriteTokens(usage);
 	return input + output + cache;
+}
+
+function extractCacheReadTokens(usage: any): number {
+	if (!usage) return 0;
+	return readNumber(usage.cacheRead) + readNumber(usage.cache_read) + readNumber(usage.cacheReadTokens) + readNumber(usage.cache_read_tokens);
+}
+
+function extractCacheWriteTokens(usage: any): number {
+	if (!usage) return 0;
+	return readNumber(usage.cacheWrite) + readNumber(usage.cache_write) + readNumber(usage.cacheWriteTokens) + readNumber(usage.cache_write_tokens);
+}
+
+function extractInputTokens(usage: any): number {
+	if (!usage) return 0;
+	return readNumber(usage.promptTokens) || readNumber(usage.prompt_tokens) || readNumber(usage.inputTokens) || readNumber(usage.input_tokens) || readNumber(usage.input);
+}
+
+function extractOutputTokens(usage: any): number {
+	if (!usage) return 0;
+	return readNumber(usage.completionTokens) || readNumber(usage.completion_tokens) || readNumber(usage.outputTokens) || readNumber(usage.output_tokens) || readNumber(usage.output);
+}
+
+function extractContextTokens(usage: any): number {
+	if (!usage) return 0;
+	return readNumber(usage.contextTokens) || readNumber(usage.context_tokens) || readNumber(usage.context);
+}
+
+function extractMaxContextTokens(usage: any): number {
+	if (!usage) return 0;
+	return readNumber(usage.maxContextTokens) || readNumber(usage.max_context_tokens) || readNumber(usage.contextWindow) || readNumber(usage.context_window);
 }
 
 function extractCost(usage: any): number {
@@ -185,11 +288,131 @@ function extractCost(usage: any): number {
 	return readNumber(usage.cost?.total);
 }
 
+function cleanTitle(value: string): string {
+	return value.replace(/\s+/g, " ").trim();
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function extractTextContent(content: unknown): string | null {
+	if (typeof content === "string") return cleanTitle(content);
+	if (!Array.isArray(content)) return null;
+	const text = content
+		.filter((part) => typeof part === "object" && part !== null && (part as { type?: unknown }).type === "text")
+		.map((part) => String((part as { text?: unknown }).text ?? ""))
+		.join(" ");
+	return text.trim() ? cleanTitle(text) : null;
+}
+
+function safeDecodeText(text: string): string {
+	try {
+		return decodeURIComponent(text);
+	} catch {
+		return text.replace(/%20/g, " ");
+	}
+}
+
+function formatIssueLink(repo: string, issueNumber: string): string {
+	return `[issue #${issueNumber}](https://github.com/${repo}/issues/${issueNumber})`;
+}
+
+function repoBasename(repo: string | null): string | null {
+	if (!repo) return null;
+	return repo.split("/").filter(Boolean).pop() ?? null;
+}
+
+function inferGitHubRepoFromPath(path: string | null): string | null {
+	if (!path) return null;
+	const parts = path.replace(/\\/g, "/").split("/").filter(Boolean);
+	const worktreesIndex = parts.indexOf("worktrees");
+	if (worktreesIndex >= 0 && parts[worktreesIndex + 1] && parts[worktreesIndex + 2]) return `${parts[worktreesIndex + 1]}/${parts[worktreesIndex + 2]}`;
+	for (let index = 0; index < parts.length - 2; index++) {
+		if (parts[index] !== "dev" || parts[index + 2] === "worktrees") continue;
+		const homeUser = parts[index - 2] === "Users" || parts[index - 2] === "home" ? parts[index - 1] : null;
+		if (homeUser && parts[index + 1] === homeUser) return `${parts[index + 1]}/${parts[index + 2]}`;
+		if (!COMMON_REPO_SUBDIRECTORIES.has(parts[index + 2])) return `${parts[index + 1]}/${parts[index + 2]}`;
+	}
+	return null;
+}
+
+const COMMON_REPO_SUBDIRECTORIES = new Set(["app", "apps", "bin", "docs", "examples", "lib", "packages", "scripts", "src", "test", "tests"]);
+
+function inferDisplayRepo(session: { repo: string | null; cwd?: string | null }): string | null {
+	return repoBasename(session.repo) ?? (session.cwd ? basename(session.cwd) : null);
+}
+
+function cleanupCompactSessionTitle(text: string): string {
+	const decoded = safeDecodeText(cleanTitle(text));
+	const issueUrl = decoded.match(/^(.*?)(?:https?:\/\/)?github\.com\/([^\s/]+)\/([^\s/]+)\/issues\/(\d+)(.*)$/i);
+	if (!issueUrl) return cleanTitle(decoded);
+
+	const prefix = cleanTitle(issueUrl[1].replace(/[-–—:]\s*$/, ""));
+	const issueLabel = formatIssueLink(`${issueUrl[2]}/${issueUrl[3]}`, issueUrl[4]);
+	return prefix ? `${prefix} - ${issueLabel}` : issueLabel;
+}
+
+function summarizeUserText(text: string, defaultRepo: string | null = null): string {
+	const cleaned = cleanupCompactSessionTitle(text);
+	if (cleaned !== cleanTitle(text)) return cleaned;
+
+	const issueTitle = cleaned.match(/^(.*?)(?:issue|#)\s*#?(\d+)\s*[:—-]\s*([^\n.]+)/i);
+	if (issueTitle?.[3]?.trim()) {
+		const prefix = cleanTitle(issueTitle[1].replace(/[-–—:]\s*$/, ""));
+		const label = `${defaultRepo ? formatIssueLink(defaultRepo, issueTitle[2]) : `issue #${issueTitle[2]}`} - ${cleanTitle(issueTitle[3])}`;
+		return prefix ? `${prefix} - ${label}` : label;
+	}
+
+	const issueUrl = cleaned.match(/(?:https?:\/\/)?github\.com\/([^\s/]+\/[^\s/]+)\/issues\/(\d+)/i);
+	if (issueUrl) return `issue #${issueUrl[2]}`;
+
+	const issueRef = cleaned.match(/^(.*?)(?:issue\s+#?|#)(\d+)\b/i);
+	if (issueRef) {
+		const prefix = cleanTitle(issueRef[1].replace(/[-–—:]\s*$/, ""));
+		const label = defaultRepo ? formatIssueLink(defaultRepo, issueRef[2]) : `issue #${issueRef[2]}`;
+		return prefix ? `${prefix} - ${label}` : label;
+	}
+
+	return cleanTitle(cleaned.replace(/(?:https?:\/\/)?github\.com\/\S+/gi, "").replace(/\s+/g, " ")) || cleaned;
+}
+
+function humanizeSlug(value: string): string {
+	return cleanTitle(
+		value
+			.replace(/\.jsonl$/, "")
+			.replace(/^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z_/, "")
+			.replace(/[._-]+/g, " "),
+	);
+}
+
+function deriveFallbackTitle(state: SessionParseState): string | null {
+	if (state.firstUserText) return summarizeUserText(state.firstUserText, inferGitHubRepoFromPath(state.cwd));
+	if (state.cwd) return humanizeSlug(basename(state.cwd));
+	const title = humanizeSlug(basename(state.filePath));
+	return title || null;
+}
+
+function inferWorkflowType(session: ParsedSession): string {
+	const text = basename(session.filePath).toLowerCase();
+	if (/(^|[-_])(?:pac-)?lwot([-_.]|$)/.test(text)) return "lwot";
+	if (/(^|[-_])grill([-_.]|$)/.test(text)) return "grill";
+	if (/(^|[-_])review([-_.]|$)/.test(text)) return "review";
+	if (/(^|[-_])triage([-_.]|$)/.test(text)) return "triage";
+	if (/\b(implement|implementation|feature|bugfix|fix|commit)\b|feature[-_]|bugfix[-_]/.test(text)) return "implementation";
+	return "other";
+}
+
 export function parseSessionStartFromFilename(name: string): Date | null {
 	const match = name.match(/^(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z_/);
 	if (!match) return null;
 	const date = new Date(`${match[1]}T${match[2]}:${match[3]}:${match[4]}.${match[5]}Z`);
 	return Number.isFinite(date.getTime()) ? date : null;
+}
+
+function parseSessionIdFromFilename(name: string): string | null {
+	const match = name.match(/^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z_(.+)\.jsonl$/);
+	return match?.[1] ?? null;
 }
 
 export function parseSessionLines(content: string, filePath = "session.jsonl"): ParsedSession | null {
@@ -203,12 +426,23 @@ export function parseSessionLines(content: string, filePath = "session.jsonl"): 
 function createSessionParseState(filePath: string): SessionParseState {
 	return {
 		filePath,
+		sessionId: parseSessionIdFromFilename(basename(filePath)),
+		title: null,
+		repo: null,
+		firstUserText: null,
 		startedAt: parseSessionStartFromFilename(basename(filePath)),
 		cwd: null,
 		currentModel: null,
 		messages: 0,
 		tokens: 0,
 		totalCost: 0,
+		cacheReadTokens: 0,
+		cacheWriteTokens: 0,
+		inputTokens: 0,
+		outputTokens: 0,
+		contextTokensTotal: 0,
+		contextSamples: 0,
+		maxContextTokens: 0,
 		skippedLines: 0,
 		modelsUsed: new Set(),
 		messagesByModel: new Map(),
@@ -228,11 +462,20 @@ function parseSessionLine(state: SessionParseState, line: string): void {
 	}
 
 	if (entry?.type === "session") {
+		if (typeof entry.id === "string" && entry.id.trim()) state.sessionId = entry.id.trim();
 		if (!state.startedAt && typeof entry.timestamp === "string") {
 			const date = new Date(entry.timestamp);
 			if (Number.isFinite(date.getTime())) state.startedAt = date;
 		}
-		if (typeof entry.cwd === "string" && entry.cwd.trim()) state.cwd = entry.cwd.trim();
+		if (typeof entry.cwd === "string" && entry.cwd.trim()) {
+			state.cwd = entry.cwd.trim();
+			state.repo = inferGitHubRepoFromPath(state.cwd);
+		}
+		return;
+	}
+
+	if (entry?.type === "session_info") {
+		if (typeof entry.name === "string" && entry.name.trim()) state.title = summarizeUserText(entry.name, inferGitHubRepoFromPath(state.cwd));
 		return;
 	}
 
@@ -247,13 +490,29 @@ function parseSessionLine(state: SessionParseState, line: string): void {
 
 	if (entry?.type !== "message") return;
 	const fields = extractMessageFields(entry);
+	if (!state.firstUserText && entry?.message?.role === "user") state.firstUserText = extractTextContent(entry.message.content);
 	const key = modelKeyFromFields(fields.provider, fields.model, fields.modelId) ?? state.currentModel ?? "unknown";
 	const entryTokens = extractTokens(fields.usage);
 	const entryCost = extractCost(fields.usage);
+	const cacheReadTokens = extractCacheReadTokens(fields.usage);
+	const cacheWriteTokens = extractCacheWriteTokens(fields.usage);
+	const inputTokens = extractInputTokens(fields.usage);
+	const outputTokens = extractOutputTokens(fields.usage);
+	const contextTokens = extractContextTokens(fields.usage);
+	const maxContextTokens = extractMaxContextTokens(fields.usage);
 
 	state.messages += 1;
 	state.tokens += entryTokens;
 	state.totalCost += entryCost;
+	state.cacheReadTokens += cacheReadTokens;
+	state.cacheWriteTokens += cacheWriteTokens;
+	state.inputTokens += inputTokens;
+	state.outputTokens += outputTokens;
+	if (contextTokens > 0) {
+		state.contextTokensTotal += contextTokens;
+		state.contextSamples += 1;
+	}
+	state.maxContextTokens = Math.max(state.maxContextTokens, contextTokens, maxContextTokens);
 	state.modelsUsed.add(key);
 	addToMap(state.messagesByModel, key, 1);
 	addToMap(state.tokensByModel, key, entryTokens);
@@ -264,13 +523,24 @@ function finalizeSessionParseState(state: SessionParseState): ParsedSession | nu
 	if (!state.startedAt) return null;
 	return {
 		filePath: state.filePath,
+		sessionId: state.sessionId,
+		title: state.title ?? deriveFallbackTitle(state),
+		repo: state.repo,
 		startedAt: state.startedAt,
 		dayKey: toDayKey(state.startedAt),
 		cwd: state.cwd,
+		cwdGroup: state.cwd,
 		modelsUsed: state.modelsUsed,
 		messages: state.messages,
 		tokens: state.tokens,
 		totalCost: state.totalCost,
+		cacheReadTokens: state.cacheReadTokens,
+		cacheWriteTokens: state.cacheWriteTokens,
+		inputTokens: state.inputTokens,
+		outputTokens: state.outputTokens,
+		contextTokensTotal: state.contextTokensTotal,
+		contextSamples: state.contextSamples,
+		maxContextTokens: state.maxContextTokens,
 		messagesByModel: state.messagesByModel,
 		tokensByModel: state.tokensByModel,
 		costByModel: state.costByModel,
@@ -286,13 +556,69 @@ async function parseSessionFile(filePath: string, signal?: AbortSignal): Promise
 			if (signal?.aborted) return { session: null, skippedLines: state.skippedLines };
 			parseSessionLine(state, line);
 		}
-		return { session: finalizeSessionParseState(state), skippedLines: state.skippedLines };
+		const session = finalizeSessionParseState(state);
+		if (session?.cwd) {
+			try {
+				session.cwdGroup = await resolveCanonicalDirectoryGroup(session.cwd);
+			} catch {
+				session.cwdGroup = session.cwd;
+			}
+		}
+		return { session, skippedLines: state.skippedLines };
 	} catch {
 		return { session: null, skippedLines: state.skippedLines, error: `Could not read ${basename(filePath)}` };
 	} finally {
 		reader.close();
 		stream.destroy();
 	}
+}
+
+const canonicalDirectoryGroupCache = new Map<string, Promise<string>>();
+
+async function resolveCanonicalDirectoryGroup(cwd: string): Promise<string> {
+	let cached = canonicalDirectoryGroupCache.get(cwd);
+	if (!cached) {
+		cached = resolveCanonicalDirectoryGroupUncached(cwd).catch((error) => {
+			canonicalDirectoryGroupCache.delete(cwd);
+			throw error;
+		});
+		canonicalDirectoryGroupCache.set(cwd, cached);
+	}
+	return cached;
+}
+
+async function resolveCanonicalDirectoryGroupUncached(cwd: string): Promise<string> {
+	const worktreeFallback = inferCanonicalRepoPathFromWorktreePath(cwd);
+	let current = cwd;
+	while (true) {
+		const dotGit = join(current, ".git");
+		try {
+			const metadata = await stat(dotGit);
+			if (metadata.isDirectory()) return current;
+			if (metadata.isFile()) {
+				const text = await readFile(dotGit, "utf8");
+				const match = text.match(/^gitdir:\s*(.+)\s*$/m);
+				if (!match) return current;
+				const gitDir = resolve(current, match[1]);
+				const commonDirText = await readFile(join(gitDir, "commondir"), "utf8").catch(() => "");
+				const commonGitDir = commonDirText.trim() ? resolve(gitDir, commonDirText.trim()) : gitDir;
+				return basename(commonGitDir) === ".git" ? dirname(commonGitDir) : current;
+			}
+		} catch {
+			// Keep walking toward the filesystem root.
+		}
+
+		const parent = dirname(current);
+		if (parent === current) return worktreeFallback ?? cwd;
+		current = parent;
+	}
+}
+
+function inferCanonicalRepoPathFromWorktreePath(path: string): string | null {
+	const normalized = path.replace(/\\/g, "/");
+	const match = normalized.match(/^(.*\/dev)\/worktrees\/([^/]+)\/([^/]+)(?:\/.*)?$/);
+	if (!match) return null;
+	return `${match[1]}/${match[2]}/${match[3]}`;
 }
 
 async function walkSessionFiles(root: string, cutoff: Date, signal?: AbortSignal): Promise<{ files: string[]; unreadableFiles: number; lastError?: string }> {
@@ -368,6 +694,16 @@ function createRangeAggregate(days: number, now: Date): RangeAggregate {
 		cwdMessages: new Map(),
 		cwdTokens: new Map(),
 		cwdCost: new Map(),
+		sessionCosts: [],
+		topCostSessions: [],
+		workflowStats: new Map(),
+		cacheReadTokens: 0,
+		cacheWriteTokens: 0,
+		inputTokens: 0,
+		outputTokens: 0,
+		contextTokensTotal: 0,
+		contextSamples: 0,
+		maxContextTokens: 0,
 	};
 }
 
@@ -379,6 +715,31 @@ function addSession(range: RangeAggregate, session: ParsedSession): void {
 	range.totalMessages += session.messages;
 	range.totalTokens += session.tokens;
 	range.totalCost += session.totalCost;
+	range.cacheReadTokens += session.cacheReadTokens;
+	range.cacheWriteTokens += session.cacheWriteTokens;
+	range.inputTokens += session.inputTokens;
+	range.outputTokens += session.outputTokens;
+	range.contextTokensTotal += session.contextTokensTotal;
+	range.contextSamples += session.contextSamples;
+	range.maxContextTokens = Math.max(range.maxContextTokens, session.maxContextTokens);
+	range.sessionCosts.push(session.totalCost);
+	if (session.totalCost > 0) {
+		range.topCostSessions.push({
+			filePath: session.filePath,
+			sessionId: session.sessionId,
+			title: session.title,
+			repo: session.repo,
+			cwd: session.cwd,
+			startedAt: session.startedAt,
+			totalCost: session.totalCost,
+			messages: session.messages,
+			tokens: session.tokens,
+			mainModel: getMainModel(session),
+		});
+		range.topCostSessions.sort((a, b) => b.totalCost - a.totalCost || a.filePath.localeCompare(b.filePath));
+		range.topCostSessions = range.topCostSessions.slice(0, 5);
+	}
+	addToWorkflowMap(range.workflowStats, inferWorkflowType(session), session);
 	day.sessions += 1;
 	day.messages += session.messages;
 	day.tokens += session.tokens;
@@ -389,11 +750,12 @@ function addSession(range: RangeAggregate, session: ParsedSession): void {
 	for (const [model, count] of session.tokensByModel) addToMap(range.modelTokens, model, count);
 	for (const [model, count] of session.costByModel) addToMap(range.modelCost, model, count);
 
-	if (session.cwd) {
-		addToMap(range.cwdSessions, session.cwd, 1);
-		addToMap(range.cwdMessages, session.cwd, session.messages);
-		addToMap(range.cwdTokens, session.cwd, session.tokens);
-		addToMap(range.cwdCost, session.cwd, session.totalCost);
+	const cwdGroup = session.cwdGroup ?? session.cwd;
+	if (cwdGroup) {
+		addToMap(range.cwdSessions, cwdGroup, 1);
+		addToMap(range.cwdMessages, cwdGroup, session.messages);
+		addToMap(range.cwdTokens, cwdGroup, session.tokens);
+		addToMap(range.cwdCost, cwdGroup, session.totalCost);
 	}
 }
 
@@ -410,7 +772,7 @@ export async function analyzeSessionDirectory(options: AnalyzeSessionDirectoryOp
 	let unreadableFiles = scanned.unreadableFiles;
 	let skippedLines = 0;
 	let lastError = scanned.lastError;
-	for (const file of scanned.files) {
+	for (const file of scanned.files.sort()) {
 		if (options.signal?.aborted) break;
 		const { session, skippedLines: fileSkippedLines, error } = await parseSessionFile(file, options.signal);
 		skippedLines += fileSkippedLines;
@@ -449,8 +811,310 @@ function formatCost(value: number): string {
 	return `$${value.toFixed(4)}`;
 }
 
+function formatCostFixed(value: number): string {
+	if (!Number.isFinite(value)) return "$0.00";
+	return `$${value.toFixed(2)}`;
+}
+
+function formatPercent(value: number): string {
+	if (!Number.isFinite(value) || value <= 0) return "0.0%";
+	return `${(value * 100).toFixed(1)}%`;
+}
+
+function formatDate(date: Date): string {
+	return date.toISOString().slice(0, 10);
+}
+
 function sortMap(map: Map<string, number>): Array<[string, number]> {
 	return [...map.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+}
+
+type ColorName = "bold" | "dim" | "blue" | "cyan" | "yellow" | "red";
+
+const ANSI: Record<ColorName, [string, string]> = {
+	bold: ["\u001b[1m", "\u001b[22m"],
+	dim: ["\u001b[2m", "\u001b[22m"],
+	blue: ["\u001b[34m", "\u001b[39m"],
+	cyan: ["\u001b[36m", "\u001b[39m"],
+	yellow: ["\u001b[33m", "\u001b[39m"],
+	red: ["\u001b[31m", "\u001b[39m"],
+};
+
+function colorize(text: string, color: ColorName, enabled: boolean): string {
+	if (!enabled) return text;
+	const [open, close] = ANSI[color];
+	return `${open}${text}${close}`;
+}
+
+function padCell(value: string, width: number): string {
+	return value.length >= width ? value : `${value}${" ".repeat(width - value.length)}`;
+}
+
+function visibleLength(value: string): number {
+	return value
+		.replace(/\[([^\]]+)\]\([^\)]+\)/g, "$1")
+		.replace(/\u001b\[[0-9;]*m/g, "")
+		.length;
+}
+
+function fitCell(value: string, width: number): string {
+	const length = visibleLength(value);
+	if (length <= width) return `${value}${" ".repeat(width - length)}`;
+	if (width <= 1) return "…";
+	return `${truncateToVisibleLength(value, width - 1)}…`;
+}
+
+function truncateToVisibleLength(value: string, maxVisibleLength: number): string {
+	let result = "";
+	let index = 0;
+	let visible = 0;
+	while (index < value.length && visible < maxVisibleLength) {
+		const ansi = value.slice(index).match(/^\u001b\[[0-9;]*m/);
+		if (ansi) {
+			result += ansi[0];
+			index += ansi[0].length;
+			continue;
+		}
+
+		const link = value.slice(index).match(/^\[([^\]]+)\]\(([^)]+)\)/);
+		if (link) {
+			const label = link[1];
+			const remaining = maxVisibleLength - visible;
+			if (label.length <= remaining) {
+				result += link[0];
+				visible += label.length;
+			} else {
+				result += label.slice(0, remaining);
+				visible = maxVisibleLength;
+			}
+			index += link[0].length;
+			continue;
+		}
+
+		result += value[index];
+		index += 1;
+		visible += 1;
+	}
+	return result;
+}
+
+function stripMarkdownLinks(value: string): string {
+	return value.replace(/\[([^\]]+)\]\([^\)]+\)/g, "$1");
+}
+
+function compactCell(value: string, width: number): string {
+	return fitCell(stripMarkdownLinks(value), width);
+}
+
+function formatRatio(value: number): string {
+	if (!Number.isFinite(value) || value <= 0) return "0×";
+	return `${value.toFixed(1)}×`;
+}
+
+function formatCostPerMessage(value: number): string {
+	if (!Number.isFinite(value) || value <= 0) return "$0";
+	return `$${value.toFixed(4)}`;
+}
+
+function formatCostPerMillionTokens(cost: number, tokens: number): string {
+	if (!Number.isFinite(cost) || !Number.isFinite(tokens) || tokens <= 0) return "$0";
+	return `$${((cost / tokens) * 1_000_000).toFixed(2)}`;
+}
+
+function cacheHealth(leverage: number): string | null {
+	if (!Number.isFinite(leverage) || leverage <= 0) return null;
+	if (leverage >= 50) return "excellent reuse";
+	if (leverage >= 10) return "good reuse";
+	if (leverage >= 3) return "moderate reuse";
+	return "low reuse";
+}
+
+function formatOverviewRow(label: string, range: RangeAggregate): string {
+	const cells = [
+		fitCell(label, 7),
+		fitCell(formatNumber(range.sessions), 8),
+		fitCell(formatNumber(range.totalMessages), 8),
+		fitCell(formatNumber(range.totalTokens), 8),
+		fitCell(formatCost(range.totalCost), 8),
+		fitCell(formatCost(range.totalCost / Number(label.replace("d", ""))), 8),
+	];
+	return `│ ${cells.join(" │ ")} │`;
+}
+
+function renderBar(value: number, maxValue: number, width = 28): string {
+	if (value <= 0 || maxValue <= 0) return "".padEnd(width);
+	const filled = Math.max(1, Math.round((value / maxValue) * width));
+	return "█".repeat(filled).padEnd(width);
+}
+
+function formatCostBars(
+	title: string,
+	costs: Map<string, number>,
+	totalCost: number,
+	options: { homeDir?: string; color: boolean; transformKey?: (key: string) => string },
+): string[] {
+	const rows = sortMap(costs).slice(0, 3);
+	if (rows.length === 0) return [colorize(title, "bold", options.color), "  none"];
+	const maxCost = rows[0]?.[1] ?? 0;
+	return [
+		colorize(title, "bold", options.color),
+		...rows.map(([key, cost]) => {
+			const displayKey = options.transformKey ? options.transformKey(key) : key;
+			const share = totalCost > 0 ? cost / totalCost : 0;
+			return `${colorize(fitCell(displayKey, 44), "blue", options.color)} ${padCell(formatCost(cost), 8)} ${colorize(renderBar(cost, maxCost), "cyan", options.color)} ${formatPercent(share)}`;
+		}),
+	];
+}
+
+function buildInsights(report: SessionBreakdownReport): string[] {
+	const seven = report.ranges.get(7);
+	const thirty = report.ranges.get(30);
+	const ninety = report.ranges.get(90);
+	if (!seven) return ["No session cost data found in the selected 90 day window."];
+
+	const insights: string[] = [];
+	if (seven.totalCost > 0) insights.push(`⚠️  Current pace projects to ~$${Math.round((seven.totalCost / 7) * 30).toLocaleString("en-US")}/month.`);
+	if (seven.totalCost > 0 && thirty && thirty.totalCost > 0) {
+		const ratio = seven.totalCost / 7 / (thirty.totalCost / 30);
+		if (ratio >= 1.5) insights.push(`🔥 Usage is accelerating: 7d daily cost is ${ratio.toFixed(1)}× the 30d average.`);
+	}
+	if (seven.totalCost > 0) {
+		const topCost = seven.topCostSessions.reduce((sum, session) => sum + session.totalCost, 0);
+		if (topCost > 0) insights.push(`🎯 Top ${seven.topCostSessions.length} sessions account for ${formatPercent(topCost / seven.totalCost)} of 7d cost.`);
+	}
+	if (seven.totalCost > 0 && ninety && ninety.totalCost > 0) insights.push(`📈 Last 7d already represents ${formatPercent(seven.totalCost / ninety.totalCost)} of 90d spend.`);
+	return insights.length > 0 ? insights : ["No paid usage found in the selected 90 day window."];
+}
+
+function compactBranchName(name: string): string | null {
+	const parts = name.split(/[-_]+/).filter(Boolean);
+	const typeIndex = parts.findIndex((part, index) => ["feature", "bugfix", "release"].includes(part) && /^\d+$/.test(parts[index + 1] ?? ""));
+	if (typeIndex === -1) return null;
+	const prefix = parts.slice(typeIndex, typeIndex + 2);
+	const stopWords = new Set(["add", "agent", "stuff", "usage", "stats", "for", "from", "with", "investigate", "implement", "implementation", "improve", "improvements"]);
+	const topic = parts.slice(typeIndex + 2).filter((part) => !stopWords.has(part));
+	return [...prefix, ...topic.slice(-3)].join("-");
+}
+
+function compactPathLabel(path: string, homeDir: string | undefined, maxLength = 44): string {
+	const display = abbreviatePath(path, homeDir, maxLength);
+	if (display.length <= maxLength) return display;
+	const branchName = compactBranchName(basename(path));
+	if (branchName) return abbreviatePath(`~/worktrees/${branchName}`, "~", maxLength).replace(/^~\/worktrees\//, "~/…/");
+	return fitCell(display, maxLength).trimEnd();
+}
+
+function formatShortSessionId(id: string | null): string {
+	if (!id) return "unknown";
+	return id.length <= 16 ? id : `${id.slice(0, 8)}…${id.slice(-6)}`;
+}
+
+function formatCompactModelName(model: string | null): string {
+	if (!model) return "unknown";
+	const name = model.split("/").pop() ?? model;
+	return name.replace(/^claude-/, "");
+}
+
+function normalizeTitleForRepo(title: string, repo: string | null): string {
+	const repoName = repoBasename(repo);
+	let normalized = title;
+	if (repo) normalized = normalized.replace(new RegExp(`^${escapeRegExp(repo)}\\s+`, "i"), "");
+	if (repoName) normalized = normalized.replace(new RegExp(`^${escapeRegExp(repoName)}\\s+`, "i"), "");
+	return cleanTitle(normalized.replace(/^[-–—:·]\s*/, ""));
+}
+
+function compactSessionTitle(session: CostSessionSummary, width: number): string {
+	const title = normalizeTitleForRepo(session.title ?? humanizeSlug(basename(session.filePath)), session.repo);
+	const repo = inferDisplayRepo(session);
+	const display = repo ? `${repo} · ${title}` : title;
+	return fitCell(display, width).trimEnd();
+}
+
+function formatOutlierSummary(range: RangeAggregate, options: { homeDir?: string; color: boolean; costCenterRange?: RangeAggregate }): string[] {
+	const lines = [colorize("Outliers · 7d", "bold", options.color)];
+	const mostExpensive = range.topCostSessions[0];
+	if (!mostExpensive) return [...lines, "  none"];
+	const topFiveCost = range.topCostSessions.slice(0, 5).reduce((sum, session) => sum + session.totalCost, 0);
+	const costCenterRange = options.costCenterRange;
+	const mainCostCenter = costCenterRange ? sortMap(costCenterRange.cwdCost)[0] : undefined;
+	lines.push(
+		` ${colorize("🔴", "red", options.color)} Most expensive session: ${formatCost(mostExpensive.totalCost)} · ${formatShortSessionId(mostExpensive.sessionId)} · ${compactSessionTitle(mostExpensive, 56)}`,
+		` 🎯 Top ${Math.min(5, range.topCostSessions.length)} sessions: ${formatCost(topFiveCost)} · ${formatPercent(range.totalCost > 0 ? topFiveCost / range.totalCost : 0)} of 7d cost`,
+	);
+	if (mainCostCenter && costCenterRange && costCenterRange.totalCost > 0) {
+		const [cwd, cost] = mainCostCenter;
+		lines.push(
+			` 🧱 Main cost center: ${compactPathLabel(cwd, options.homeDir, 42)} · ${formatPercent(cost / costCenterRange.totalCost)} of 30d spend`,
+		);
+	}
+	return lines;
+}
+
+function formatSessionDrillDown(range: RangeAggregate, color: boolean): string[] {
+	const lines = [colorize("Session drill-down · 7d · top 5 by cost", "bold", color)];
+	if (range.topCostSessions.length === 0) return [...lines, "  none"];
+	lines.push(`${padCell("Cost", 7)} ${padCell("Date", 10)} ${padCell("ID", 16)} ${padCell("Msgs", 5)} ${padCell("Tokens", 7)} ${padCell("Main model", 24)} Title`);
+	for (const session of range.topCostSessions.slice(0, 5)) {
+		lines.push(
+			`${padCell(formatCost(session.totalCost), 7)} ${formatDate(session.startedAt)} ${padCell(formatShortSessionId(session.sessionId), 16)} ${padCell(formatNumber(session.messages), 5)} ${padCell(formatNumber(session.tokens), 7)} ${compactCell(formatCompactModelName(session.mainModel), 24)} ${compactSessionTitle(session, 36)}`,
+		);
+	}
+	return lines;
+}
+
+function formatModelDrillDown(range: RangeAggregate, color: boolean): string[] {
+	const rows = sortMap(range.modelCost).slice(0, 5);
+	const lines = [colorize("Model drill-down · 30d · top 5 by cost", "bold", color)];
+	if (rows.length === 0) return [...lines, "  none"];
+	lines.push(`${padCell("Model", 26)} ${padCell("Sessions", 8)} ${padCell("Msgs", 6)} ${padCell("Tokens", 8)} ${padCell("Cost", 8)} ${padCell("$/msg", 8)} $/1M tok`);
+	for (const [model, cost] of rows) {
+		const sessions = range.modelSessions.get(model) ?? 0;
+		const messages = range.modelMessages.get(model) ?? 0;
+		const tokens = range.modelTokens.get(model) ?? 0;
+		lines.push(
+			`${compactCell(model, 26)} ${padCell(formatNumber(sessions), 8)} ${padCell(formatNumber(messages), 6)} ${padCell(formatNumber(tokens), 8)} ${padCell(formatCost(cost), 8)} ${padCell(formatCostPerMessage(messages ? cost / messages : 0), 8)} ${formatCostPerMillionTokens(cost, tokens)}`,
+		);
+	}
+	return lines;
+}
+
+function formatDirectoryDrillDown(range: RangeAggregate, options: { homeDir?: string; color: boolean }): string[] {
+	const rows = sortMap(range.cwdCost).slice(0, 5);
+	const lines = [colorize("Directory drill-down · 30d · top 5 by cost", "bold", options.color)];
+	if (rows.length === 0) return [...lines, "  none"];
+	const overallAverage = range.sessions ? range.totalCost / range.sessions : 0;
+	lines.push(`${padCell("Directory", 44)} ${padCell("Sessions", 8)} ${padCell("Msgs", 6)} ${padCell("Tokens", 8)} ${padCell("Cost", 8)} Avg/session`);
+	for (const [cwd, cost] of rows) {
+		const sessions = range.cwdSessions.get(cwd) ?? 0;
+		const messages = range.cwdMessages.get(cwd) ?? 0;
+		const tokens = range.cwdTokens.get(cwd) ?? 0;
+		const averageCost = sessions ? cost / sessions : 0;
+		const warning = overallAverage > 0 && averageCost >= overallAverage * 2 ? ` ${colorize("🔴", "red", options.color)}` : "";
+		lines.push(
+			`${compactCell(compactPathLabel(cwd, options.homeDir, 44), 44)} ${padCell(formatNumber(sessions), 8)} ${padCell(formatNumber(messages), 6)} ${padCell(formatNumber(tokens), 8)} ${padCell(formatCost(cost), 8)} ${formatCostFixed(averageCost)}${warning}`,
+		);
+	}
+	return lines;
+}
+
+function formatCacheContext(range: RangeAggregate, color: boolean): string[] {
+	const lines = [colorize("Cache / context · 7d", "bold", color)];
+	if (range.cacheReadTokens > 0 || range.cacheWriteTokens > 0) {
+		lines.push(`Cache read/write   ${formatNumber(range.cacheReadTokens)} / ${formatNumber(range.cacheWriteTokens)} tokens`);
+		if (range.cacheWriteTokens > 0) {
+			const leverage = range.cacheReadTokens / range.cacheWriteTokens;
+			lines.push(`Cache leverage     ${formatRatio(leverage)} read per write`);
+			const health = cacheHealth(leverage);
+			if (health) lines.push(`Cache health       ${health}`);
+		}
+	}
+	if (range.contextSamples > 0 && range.maxContextTokens > 0) {
+		const averageContext = range.contextTokensTotal / range.contextSamples;
+		lines.push(`Avg context        ${formatNumber(averageContext)} / ${formatNumber(range.maxContextTokens)}`);
+		lines.push(`Context pressure   ${Math.round((averageContext / range.maxContextTokens) * 100)}%`);
+	}
+	if (range.inputTokens > 0 && range.outputTokens > 0) lines.push(`Input/output       ${formatRatio(range.inputTokens / range.outputTokens)}`);
+	return lines.length > 1 ? lines : [];
 }
 
 export function abbreviatePath(path: string, homeDir = homedir(), maxLength = 48): string {
@@ -479,6 +1143,60 @@ function formatOptionalTopMap(title: string, map: Map<string, number>, formatter
 	return map.size > 0 ? formatTopMap(title, map, formatter, transformKey) : [];
 }
 
+function formatCostDistribution(costs: number[]): string {
+	if (costs.length === 0) return "  cost distribution: none";
+	let sum = 0;
+	let max = 0;
+	for (const cost of costs) {
+		sum += cost;
+		if (cost > max) max = cost;
+	}
+	const sorted = [...costs].sort((a, b) => a - b);
+	const middle = Math.floor(sorted.length / 2);
+	const medianCost = sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle];
+	const p90Index = Math.max(0, Math.min(sorted.length - 1, Math.ceil(0.9 * sorted.length) - 1));
+	return `  cost distribution: avg/session ${formatCost(sum / costs.length)} · median ${formatCost(medianCost)} · p90 ${formatCost(sorted[p90Index])} · max ${formatCost(max)}`;
+}
+
+function formatTopCostSessions(sessions: CostSessionSummary[], homeDir?: string): string[] {
+	if (sessions.length === 0) return ["  top expensive sessions: none"];
+	return [
+		"  top expensive sessions:",
+		...sessions.map((session) => `    - ${formatDate(session.startedAt)} · ${abbreviatePath(session.filePath, homeDir, 64)}: ${formatCost(session.totalCost)}`),
+	];
+}
+
+function formatCostByWorkflow(map: Map<string, WorkflowAggregate>): string[] {
+	const rows = [...map.entries()].sort((a, b) => b[1].totalCost - a[1].totalCost || a[0].localeCompare(b[0])).slice(0, 5);
+	if (rows.length === 0) return ["  cost by workflow type: none"];
+	return [
+		"  cost by workflow type:",
+		...rows.map(
+			([key, value]) =>
+				`    - ${key}: ${formatCost(value.totalCost)} · avg/session ${formatCost(value.totalCost / value.sessions)} · sessions ${formatNumber(value.sessions)} · messages ${formatNumber(value.messages)} · tokens ${formatNumber(value.tokens)}`,
+		),
+	];
+}
+
+function formatCostMapWithAverages(
+	title: string,
+	costs: Map<string, number>,
+	messages: Map<string, number>,
+	sessions: Map<string, number>,
+	transformKey = (key: string) => key,
+): string[] {
+	const rows = sortMap(costs).slice(0, 5);
+	if (rows.length === 0) return [];
+	return [
+		`  ${title}:`,
+		...rows.map(([key, cost]) => {
+			const messageCount = messages.get(key) ?? 0;
+			const sessionCount = sessions.get(key) ?? 0;
+			return `    - ${transformKey(key)}: ${formatCost(cost)} · avg/message ${formatCost(messageCount ? cost / messageCount : 0)} · avg/session ${formatCost(sessionCount ? cost / sessionCount : 0)}`;
+		}),
+	];
+}
+
 export function formatBreakdownReport(report: SessionBreakdownReport, options: { homeDir?: string } = {}): string {
 	const lines = [
 		"Pi session breakdown",
@@ -503,15 +1221,76 @@ export function formatBreakdownReport(report: SessionBreakdownReport, options: {
 		lines.push(
 			`  sessions: ${formatNumber(range.sessions)} · messages: ${formatNumber(range.totalMessages)} · tokens: ${formatNumber(range.totalTokens)} · cost: ${formatCost(range.totalCost)}`,
 		);
+		lines.push(formatCostDistribution(range.sessionCosts));
+		lines.push(...formatTopCostSessions(range.topCostSessions, options.homeDir));
+		lines.push(...formatCostByWorkflow(range.workflowStats));
 		lines.push(...formatTopMap("sessions by model", range.modelSessions, formatNumber));
 		lines.push(...formatTopMap("messages by model", range.modelMessages, formatNumber));
 		lines.push(...formatOptionalTopMap("tokens by model", range.modelTokens, formatNumber));
-		lines.push(...formatOptionalTopMap("cost by model", range.modelCost, formatCost));
+		lines.push(...formatCostMapWithAverages("cost by model", range.modelCost, range.modelMessages, range.modelSessions));
 		lines.push(...formatTopMap("sessions by directory", range.cwdSessions, formatNumber, (key) => abbreviatePath(key, options.homeDir)));
 		lines.push(...formatTopMap("messages by directory", range.cwdMessages, formatNumber, (key) => abbreviatePath(key, options.homeDir)));
 		lines.push(...formatOptionalTopMap("tokens by directory", range.cwdTokens, formatNumber, (key) => abbreviatePath(key, options.homeDir)));
-		lines.push(...formatOptionalTopMap("cost by directory", range.cwdCost, formatCost, (key) => abbreviatePath(key, options.homeDir)));
+		lines.push(...formatCostMapWithAverages("cost by directory", range.cwdCost, range.cwdMessages, range.cwdSessions, (key) => abbreviatePath(key, options.homeDir)));
 	}
 
+	return lines.join("\n");
+}
+
+export function formatCompactBreakdownReport(report: SessionBreakdownReport, options: { homeDir?: string; color?: boolean } = {}): string {
+	const color = options.color ?? true;
+	const seven = report.ranges.get(7);
+	const thirty = report.ranges.get(30);
+	const ninety = report.ranges.get(90);
+	const lines = [
+		colorize("Pi session breakdown", "bold", color),
+		`${colorize("Source:", "dim", color)} ${abbreviatePath(report.root, options.homeDir)}`,
+		`Local aggregate stats only · ${formatNumber(report.parsedSessions)} sessions parsed`,
+	];
+
+	if (report.unreadableFiles > 0 || report.skippedLines > 0) {
+		const parts = [];
+		if (report.unreadableFiles > 0) parts.push(`${report.unreadableFiles} unreadable file(s)`);
+		if (report.skippedLines > 0) parts.push(`${report.skippedLines} malformed JSONL line(s)`);
+		lines.push(colorize(`Warning: skipped ${parts.join(" and ")}.${report.lastError ? ` Last error: ${report.lastError}.` : ""}`, "yellow", color));
+	}
+
+	lines.push(
+		"",
+		colorize("Overview", "bold", color),
+		"┌─────────┬──────────┬──────────┬──────────┬──────────┬──────────┐",
+		"│ Window  │ Sessions │ Messages │ Tokens   │ Cost     │ Daily avg│",
+		"├─────────┼──────────┼──────────┼──────────┼──────────┼──────────┤",
+	);
+	if (seven) lines.push(formatOverviewRow("7d", seven));
+	if (thirty) lines.push(formatOverviewRow("30d", thirty));
+	if (ninety) lines.push(formatOverviewRow("90d", ninety));
+	lines.push("└─────────┴──────────┴──────────┴──────────┴──────────┴──────────┘");
+
+	lines.push("", colorize("Insights", "bold", color), ...buildInsights(report).map((line) => `  ${line}`));
+
+	if (thirty) {
+		lines.push(
+			"",
+			...formatCostBars("Cost by model · 30d spend share", thirty.modelCost, thirty.totalCost, { color }),
+			"",
+			...formatCostBars("Cost by directory · 30d spend share", thirty.cwdCost, thirty.totalCost, {
+				color,
+				transformKey: (key) => compactPathLabel(key, options.homeDir, 44),
+			}),
+		);
+	}
+
+	if (seven) lines.push("", ...formatOutlierSummary(seven, { homeDir: options.homeDir, color, costCenterRange: thirty }));
+	else lines.push("", colorize("Outliers · 7d", "bold", color), "  none");
+
+	if (seven) lines.push("", ...formatSessionDrillDown(seven, color));
+	if (thirty) {
+		lines.push("", ...formatModelDrillDown(thirty, color), "", ...formatDirectoryDrillDown(thirty, { homeDir: options.homeDir, color }));
+	}
+	if (seven) {
+		const cacheContext = formatCacheContext(seven, color);
+		if (cacheContext.length > 0) lines.push("", ...cacheContext);
+	}
 	return lines.join("\n");
 }

--- a/extensions/session-breakdown/index.ts
+++ b/extensions/session-breakdown/index.ts
@@ -1,27 +1,24 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { analyzeSessionDirectory, DEFAULT_SESSION_ROOT, formatBreakdownReport } from "./helpers.ts";
+import { analyzeSessionDirectory, DEFAULT_SESSION_ROOT, formatCompactBreakdownReport } from "./helpers.ts";
 
 export default function sessionBreakdownExtension(pi: ExtensionAPI): void {
 	pi.registerCommand("session-breakdown", {
-		description: "Show local Pi session usage stats for the last 7/30/90 days",
-		handler: async (_args, ctx) => {
+		description: "Show local Pi session usage stats with cost-focused drill-downs",
+		handler: async (args, ctx) => {
 			ctx.ui.notify("Scanning local Pi session stats…", "info");
 			const report = await analyzeSessionDirectory({ root: DEFAULT_SESSION_ROOT, signal: ctx.signal });
 			if (report.aborted || ctx.signal?.aborted) {
 				ctx.ui.notify("Session breakdown cancelled", "info");
 				return;
 			}
-			const content = formatBreakdownReport(report);
+			const flags = new Set((args ?? "").split(/\s+/).filter(Boolean));
+			const color = !flags.has("--no-color");
+			const content = formatCompactBreakdownReport(report, { color });
 			pi.sendMessage(
 				{
 					customType: "session-breakdown",
 					content,
 					display: true,
-					details: {
-						root: report.root,
-						scannedFiles: report.scannedFiles,
-						parsedSessions: report.parsedSessions,
-					},
 				},
 				{ triggerTurn: false },
 			);


### PR DESCRIPTION
- **✨ feat(session-breakdown): Add cost-focused session stats**
- **✨ feat(session-breakdown): Add compact cost report**
- **💄 feat(session-breakdown): Polish compact cost report**
- **💄 feat(session-breakdown): Refine compact outlier labels**
- **🐛 fix(session-breakdown): Clean compact issue URL titles**
- **🐛 fix(session-breakdown): Clean explicit compact titles**
- **🐛 fix(session-breakdown): Collapse duplicate title separators**
- **🐛 fix(session-breakdown): Stop issue URL titles at number**
- **✨ feat(session-breakdown): Link compact issue labels**
- **🐛 fix(session-breakdown): Use markdown issue links**
- **🐛 fix(session-breakdown): Link bare compact issue refs**
- **✨ feat(session-breakdown): Show repo for compact outliers**
- **✨ feat(session-breakdown): Add compact drill-down sections**
- **💄 feat(session-breakdown): Refine compact report UX**
- **🐛 fix(session-breakdown): Group missing worktree paths**
- **💄 fix(session-breakdown): Polish compact cost report**
