### PR TITLE
✨ feat(personas): Add runtime persona support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioned sections should match the Git tags and GitHub releases published for t
 ### Added
 
 - Added cost-focused `/session-breakdown` stats with a compact colorized default report, trend insights, model/directory cost bars, an outlier diagnostic summary, top-5 session/model/directory drill-downs, worktree-aware directory grouping, and cache/context metrics when available. ([#280](https://github.com/ladislas/mypac/issues/280))
+- Added a `/persona` Pi extension and `personas/` prompt-content directory for enabling reusable runtime personas, starting with the preserved Rick persona. ([#37](https://github.com/ladislas/mypac/issues/37))
 - Added a repo-local Worktrunk extension with `/worktree issue <issue-number-or-url>`, issue-derived branch names, create-or-reuse behavior, Worktrunk `pre-start` setup hooks, and workflow documentation for parallel Pi issue work. ([#85](https://github.com/ladislas/mypac/issues/85))
 - Added non-issue Worktrunk shortcuts for explicit branch worktrees, listing worktrees, and showing current worktree status from Pi. ([#270](https://github.com/ladislas/mypac/issues/270))
 - Added a custom Pi footer extension with write-cache token totals, provider-qualified model labels, context/budget threshold coloring, Codex/Copilot/Claude usage bars, and no default auto-compaction percentage segment. ([#265](https://github.com/ladislas/mypac/issues/265))

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **mypac** stands for **My Personal AI Config**.
 
-It is an opinionated package of reusable **Pi** assets: extensions, prompts, and skills for coding workflows.
+It is an opinionated package of reusable **Pi** assets: extensions, prompts, skills, and personas for coding workflows.
 This repo is both my personal lab and a browsable catalog for people who want to discover, copy, or install useful Pi building blocks.
 
 It is set up to be used with **[pi](https://github.com/badlogic/pi-mono/tree/main/packages/pi-coding-agent)**.
@@ -14,6 +14,7 @@ If you are evaluating this repository, the main things to look at are:
 - **Extensions** that add Pi commands, tools, UI flows, and workflow guardrails
 - **Skills** that encode repeatable repo and GitHub workflows
 - **Prompts** that turn common work modes into slash commands
+- **Personas** that can be enabled at runtime for reusable communication and judgment style
 
 In short: this is a small shop of reusable Pi assets for planning, implementation, review, GitHub work, and day-to-day repo operations.
 
@@ -35,6 +36,7 @@ For readability, the skill table below drops the `pac-` prefix in the display la
 | [`files`](extensions/files/) | `/files`, shortcuts | Browses repo and session files, with quick actions like open, reveal, diff, edit, and add to prompt |
 | [`ghi`](extensions/ghi/) | `/ghi` | Creates a GitHub issue in the current repository using `gh` |
 | [`multi-edit`](extensions/multi-edit/) | `edit` tool override | Extends Pi's `edit` tool with batch edits and Codex-style patch support |
+| [`personas`](extensions/personas/) | `/persona` | Lists, enables, and disables reusable persona prompt content from [`personas/`](personas/) |
 | [`review`](extensions/review/) | `/review-start`, `/review-end` | Reviews uncommitted changes, commits, branches, PRs, or folders from inside Pi |
 | [`session-breakdown`](extensions/session-breakdown/) | `/session-breakdown` | Shows local Pi session usage, cost, model, directory, and cache/context statistics without printing raw transcripts |
 | [`session-names`](extensions/session-names/) | background behavior | Names `/pac-lwot` sessions from the work context you provide |
@@ -157,6 +159,7 @@ The main Pi resource directories in this repository are:
 - `prompts/`
 - `extensions/`
 - `skills/`
+- `personas/` (loaded by the `personas` extension, not directly by Pi)
 
 ## Ask Pi to do the first-time setup
 

--- a/extensions/personas/README.md
+++ b/extensions/personas/README.md
@@ -1,0 +1,11 @@
+# Personas extension
+
+Adds `/persona` for reusable Pi persona content stored under the repository-level [`personas/`](../../personas/) directory.
+
+## Commands
+
+- `/persona` or `/persona list` — list available personas
+- `/persona <name>` — enable a persona for future turns
+- `/persona off` — disable the active persona
+
+The extension appends the selected persona to Pi's system prompt during `before_agent_start`. Persona text is style and judgment guidance only; it must not override higher-priority instructions, tool rules, safety constraints, project conventions, or explicit user requests.

--- a/extensions/personas/helpers.test.mjs
+++ b/extensions/personas/helpers.test.mjs
@@ -1,0 +1,182 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+	buildPersonaSystemPrompt,
+	formatPersonaList,
+	getPersonaStateFromBranch,
+	insertPersonaSystemPrompt,
+	loadPersonas,
+	parsePersonaCommand,
+} from "./helpers.ts";
+
+async function makeTempDir(t, prefix) {
+	const dir = await mkdtemp(path.join(tmpdir(), prefix));
+	t.after(() => rm(dir, { recursive: true, force: true }));
+	return dir;
+}
+
+test("loadPersonas reads root markdown persona files and strips frontmatter", async (t) => {
+	const cwd = await makeTempDir(t, "personas-");
+	await mkdir(path.join(cwd, "personas"));
+	await writeFile(
+		path.join(cwd, "personas", "rick.md"),
+		`---\nname: rick\ndescription: Chaotic genius\n---\n\n# Rick\n\nBe useful.\n`,
+		"utf8",
+	);
+	await writeFile(path.join(cwd, "personas", "notes.txt"), "ignore", "utf8");
+
+	const personas = await loadPersonas(cwd);
+
+	assert.equal(personas.length, 1);
+	assert.equal(personas[0].name, "rick");
+	assert.equal(personas[0].description, "Chaotic genius");
+	assert.equal(personas[0].content, "# Rick\n\nBe useful.");
+	assert.equal(personas[0].relativePath, "personas/rick.md");
+});
+
+test("loadPersonas returns an empty list when no personas directory exists", async (t) => {
+	const cwd = await makeTempDir(t, "personas-missing-");
+	assert.deepEqual(await loadPersonas(cwd), []);
+});
+
+test("loadPersonas tolerates CRLF frontmatter", async (t) => {
+	const cwd = await makeTempDir(t, "personas-crlf-");
+	await mkdir(path.join(cwd, "personas"));
+	await writeFile(
+		path.join(cwd, "personas", "rick.md"),
+		"---\r\nname: rick\r\ndescription: Chaotic genius\r\n---\r\n\r\n# Rick\r\n\r\nBe useful.\r\n",
+		"utf8",
+	);
+
+	const personas = await loadPersonas(cwd);
+
+	assert.equal(personas[0].name, "rick");
+	assert.equal(personas[0].description, "Chaotic genius");
+	assert.equal(personas[0].content, "# Rick\r\n\r\nBe useful.");
+});
+
+test("loadPersonas tolerates leading whitespace and BOM before frontmatter", async (t) => {
+	const cwd = await makeTempDir(t, "personas-leading-");
+	await mkdir(path.join(cwd, "personas"));
+	await writeFile(
+		path.join(cwd, "personas", "rick.md"),
+		"\uFEFF  \n---\nname: rick\ndescription: Chaotic genius\n---\n\n# Rick\n\nBe useful.\n",
+		"utf8",
+	);
+
+	const personas = await loadPersonas(cwd);
+
+	assert.equal(personas[0].name, "rick");
+	assert.equal(personas[0].description, "Chaotic genius");
+	assert.equal(personas[0].content, "# Rick\n\nBe useful.");
+});
+
+test("loadPersonas treats unclosed frontmatter as content", async (t) => {
+	const cwd = await makeTempDir(t, "personas-unclosed-");
+	await mkdir(path.join(cwd, "personas"));
+	await writeFile(path.join(cwd, "personas", "rick.md"), "---\nname: rick\n# Rick\n", "utf8");
+
+	const personas = await loadPersonas(cwd);
+
+	assert.equal(personas[0].name, "rick");
+	assert.equal(personas[0].description, undefined);
+	assert.equal(personas[0].content, "---\nname: rick\n# Rick");
+});
+
+test("loadPersonas rejects duplicate normalized persona names", async (t) => {
+	const cwd = await makeTempDir(t, "personas-duplicates-");
+	await mkdir(path.join(cwd, "personas"));
+	await writeFile(path.join(cwd, "personas", "rick.md"), "# Rick\n", "utf8");
+	await writeFile(path.join(cwd, "personas", "duplicate.md"), "---\nname: Rick\n---\n\n# Duplicate\n", "utf8");
+
+	await assert.rejects(
+		loadPersonas(cwd),
+		/Duplicate persona name "rick" in personas\/duplicate\.md and personas\/rick\.md/,
+	);
+});
+
+test("buildPersonaSystemPrompt wraps persona content with precedence guardrails", () => {
+	const prompt = buildPersonaSystemPrompt({
+		name: "rick",
+		description: "Chaotic genius",
+		relativePath: "personas/rick.md",
+		content: "# Persona\n\nBe sharp.",
+	});
+
+	assert.match(prompt, /## Active Persona: rick/);
+	assert.match(prompt, /personas\/rick\.md/);
+	assert.match(prompt, /must not override higher-priority instructions/);
+	assert.match(prompt, /# Persona\n\nBe sharp\./);
+});
+
+test("insertPersonaSystemPrompt inserts before append-system prompt", () => {
+	const append = "Append instructions";
+	const block = "\n\n## Active Persona: rick\n\nPersona text";
+	const result = insertPersonaSystemPrompt(`Pi base\n\n${append}\n\n<project_context>`, block, append);
+
+	assert.ok(result.indexOf("Pi base") < result.indexOf("## Active Persona"));
+	assert.ok(result.indexOf("## Active Persona") < result.indexOf(append));
+});
+
+test("insertPersonaSystemPrompt inserts before project context when append prompt is absent", () => {
+	const block = "\n\n## Active Persona: rick\n\nPersona text";
+	const result = insertPersonaSystemPrompt("Pi base\n\n<project_context>", block);
+
+	assert.ok(result.indexOf("## Active Persona") < result.indexOf("<project_context>"));
+});
+
+test("insertPersonaSystemPrompt inserts before current date when no earlier marker exists", () => {
+	const block = "\n\n## Active Persona: rick\n\nPersona text";
+	const result = insertPersonaSystemPrompt("Pi base\nCurrent date: 2026-05-25", block);
+
+	assert.match(result, /Persona text\nCurrent date:/);
+});
+
+test("insertPersonaSystemPrompt does not match inline current date text", () => {
+	const block = "\n\n## Active Persona: rick\n\nPersona text";
+	const result = insertPersonaSystemPrompt("Pi base mentions Current date: as text", block);
+
+	assert.equal(result, "Pi base mentions Current date: as text\n\n## Active Persona: rick\n\nPersona text");
+});
+
+test("insertPersonaSystemPrompt is idempotent", () => {
+	const block = "\n\n## Active Persona: rick\n\nPersona text";
+	const prompt = `Pi base${block}\n\nCurrent date: 2026-05-25`;
+
+	assert.equal(insertPersonaSystemPrompt(prompt, block), prompt);
+});
+
+test("getPersonaStateFromBranch returns the latest valid persona state", () => {
+	const state = getPersonaStateFromBranch([
+		{ type: "custom", customType: "persona-state", data: { activePersona: "rick" } },
+		{ type: "custom", customType: "persona-state", data: { activePersona: undefined } },
+	]);
+
+	assert.deepEqual(state, { activePersona: undefined });
+});
+
+test("parsePersonaCommand recognizes list, off, and persona selections", () => {
+	assert.deepEqual(parsePersonaCommand(undefined), { action: "list" });
+	assert.deepEqual(parsePersonaCommand("   "), { action: "list" });
+	assert.deepEqual(parsePersonaCommand("list"), { action: "list" });
+	assert.deepEqual(parsePersonaCommand("off"), { action: "off" });
+	assert.deepEqual(parsePersonaCommand("disable"), { action: "off" });
+	assert.deepEqual(parsePersonaCommand("Rick"), { action: "select", name: "rick" });
+});
+
+test("formatPersonaList marks active persona", () => {
+	const output = formatPersonaList(
+		[
+			{ name: "default", relativePath: "personas/default.md", content: "Default" },
+			{ name: "rick", description: "Chaotic genius", relativePath: "personas/rick.md", content: "Rick" },
+		],
+		"rick",
+	);
+
+	assert.match(output, /Available personas:/);
+	assert.match(output, /- default — personas\/default\.md/);
+	assert.match(output, /- rick \(active\) — Chaotic genius/);
+});

--- a/extensions/personas/helpers.ts
+++ b/extensions/personas/helpers.ts
@@ -1,0 +1,186 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+export const PERSONA_STATE_TYPE = "persona-state";
+
+const PROJECT_CONTEXT_MARKER = "<project_context>";
+const CURRENT_DATE_MARKER = "\nCurrent date:";
+
+export interface Persona {
+	name: string;
+	description?: string;
+	relativePath: string;
+	content: string;
+}
+
+export interface PersonaState {
+	activePersona?: string;
+}
+
+type PersonaStateEntry = {
+	type: string;
+	customType?: string;
+	data?: unknown;
+};
+
+export type PersonaCommand =
+	| { action: "list" }
+	| { action: "off" }
+	| { action: "select"; name: string };
+
+function parseFrontmatter(raw: string): { frontmatter: Record<string, string>; content: string } {
+	const normalized = raw.trimStart().replace(/^\uFEFF/, "").trimStart();
+	const match = normalized.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+	if (!match) return { frontmatter: {}, content: normalized.trim() };
+
+	const frontmatter: Record<string, string> = {};
+	for (const line of match[1].split(/\r?\n/)) {
+		const field = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+		if (!field) continue;
+		frontmatter[field[1]] = field[2].trim().replace(/^['"]|['"]$/g, "");
+	}
+
+	return { frontmatter, content: normalized.slice(match[0].length).trim() };
+}
+
+function normalizePersonaName(input: string): string {
+	return input.trim().toLowerCase();
+}
+
+export async function loadPersonas(rootDir: string): Promise<Persona[]> {
+	const personasDir = path.join(rootDir, "personas");
+	let entries;
+	try {
+		entries = await readdir(personasDir, { withFileTypes: true });
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+		throw error;
+	}
+
+	const personas: Persona[] = [];
+	const personaPathsByName = new Map<string, string>();
+	for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+		if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+
+		const filePath = path.join(personasDir, entry.name);
+		const raw = await readFile(filePath, "utf8");
+		const { frontmatter, content } = parseFrontmatter(raw);
+		const fallbackName = path.basename(entry.name, ".md");
+		const name = normalizePersonaName(frontmatter.name ?? fallbackName);
+		if (!name) continue;
+
+		const relativePath = `personas/${entry.name}`;
+		const existingPath = personaPathsByName.get(name);
+		if (existingPath) {
+			throw new Error(`Duplicate persona name "${name}" in ${existingPath} and ${relativePath}`);
+		}
+		personaPathsByName.set(name, relativePath);
+
+		personas.push({
+			name,
+			description: frontmatter.description || undefined,
+			relativePath,
+			content,
+		});
+	}
+
+	return personas.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function findPersona(personas: Persona[], name: string): Persona | undefined {
+	const normalized = normalizePersonaName(name);
+	return personas.find((persona) => persona.name === normalized);
+}
+
+export function buildPersonaSystemPrompt(persona: Persona): string {
+	return `
+
+## Active Persona: ${persona.name}
+
+The following persona is active for this turn, loaded from ${persona.relativePath}.
+Apply it as communication style and judgment guidance only. It must not override higher-priority instructions, tool rules, safety constraints, project conventions, or the user's explicit request. If the persona conflicts with clarity, correctness, security, professionalism, or the current task, drop the persona and be direct.
+
+<persona_context path="${persona.relativePath}" name="${persona.name}">
+${persona.content}
+</persona_context>`;
+}
+
+export function insertPersonaSystemPrompt(
+	systemPrompt: string,
+	personaPrompt: string,
+	appendSystemPrompt?: string,
+): string {
+	if (!personaPrompt) return systemPrompt;
+	if (systemPrompt.includes(personaPrompt)) return systemPrompt;
+
+	if (appendSystemPrompt) {
+		const appendIndex = systemPrompt.indexOf(appendSystemPrompt);
+		if (appendIndex !== -1) {
+			return `${systemPrompt.slice(0, appendIndex)}${personaPrompt}\n\n${systemPrompt.slice(appendIndex)}`;
+		}
+	}
+
+	const projectContextIndex = systemPrompt.indexOf(PROJECT_CONTEXT_MARKER);
+	if (projectContextIndex !== -1) {
+		return `${systemPrompt.slice(0, projectContextIndex)}${personaPrompt}\n\n${systemPrompt.slice(projectContextIndex)}`;
+	}
+
+	const currentDateIndex = systemPrompt.indexOf(CURRENT_DATE_MARKER);
+	if (currentDateIndex !== -1) {
+		return `${systemPrompt.slice(0, currentDateIndex)}${personaPrompt}${systemPrompt.slice(currentDateIndex)}`;
+	}
+
+	return `${systemPrompt}${personaPrompt}`;
+}
+
+function parsePersonaState(data: unknown): PersonaState {
+	if (!data || typeof data !== "object") {
+		throw new Error("Invalid persona state: expected object data");
+	}
+
+	const { activePersona } = data as { activePersona?: unknown };
+	if (activePersona !== undefined && typeof activePersona !== "string") {
+		throw new Error("Invalid persona state: expected activePersona string or undefined");
+	}
+
+	return { activePersona };
+}
+
+export function getPersonaStateFromBranch(entries: PersonaStateEntry[]): PersonaState | undefined {
+	let state: PersonaState | undefined;
+
+	for (const entry of entries) {
+		if (entry.type === "custom" && entry.customType === PERSONA_STATE_TYPE) {
+			state = parsePersonaState(entry.data);
+		}
+	}
+
+	return state;
+}
+
+export function parsePersonaCommand(args: string | undefined): PersonaCommand {
+	const trimmed = args?.trim() ?? "";
+	if (!trimmed || trimmed.toLowerCase() === "list") return { action: "list" };
+
+	const normalized = trimmed.toLowerCase();
+	if (["off", "none", "disable", "disabled"].includes(normalized)) {
+		return { action: "off" };
+	}
+
+	return { action: "select", name: normalized };
+}
+
+export function formatPersonaList(personas: Persona[], activePersona?: string): string {
+	if (personas.length === 0) {
+		return "No personas found. Add Markdown persona files under personas/.";
+	}
+
+	const lines = ["Available personas:"];
+	for (const persona of personas) {
+		const active = persona.name === activePersona ? " (active)" : "";
+		const detail = persona.description ?? persona.relativePath;
+		lines.push(`- ${persona.name}${active} — ${detail}`);
+	}
+	lines.push("Use /persona <name> to enable one, or /persona off to disable.");
+	return lines.join("\n");
+}

--- a/extensions/personas/index.ts
+++ b/extensions/personas/index.ts
@@ -1,0 +1,99 @@
+import { fileURLToPath } from "node:url";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import {
+	buildPersonaSystemPrompt,
+	findPersona,
+	formatPersonaList,
+	getPersonaStateFromBranch,
+	insertPersonaSystemPrompt,
+	loadPersonas,
+	parsePersonaCommand,
+	PERSONA_STATE_TYPE,
+	type Persona,
+} from "./helpers.ts";
+
+export default function personasExtension(pi: ExtensionAPI): void {
+	const packageRoot = fileURLToPath(new URL("../../", import.meta.url));
+	let personas: Persona[] = [];
+	let personasLoaded = false;
+	let activePersona: string | undefined;
+
+	function updateStatus(ctx: ExtensionContext): void {
+		ctx.ui.setStatus(
+			"persona",
+			activePersona ? ctx.ui.theme.fg("accent", `🎭 ${activePersona}`) : undefined,
+		);
+	}
+
+	async function loadAvailablePersonas(_ctx: ExtensionContext): Promise<void> {
+		if (personasLoaded) return;
+		personas = await loadPersonas(packageRoot);
+		personasLoaded = true;
+	}
+
+	function restoreFromBranch(ctx: ExtensionContext): void {
+		activePersona = getPersonaStateFromBranch(ctx.sessionManager.getBranch())?.activePersona;
+		if (activePersona && !findPersona(personas, activePersona)) {
+			activePersona = undefined;
+		}
+		updateStatus(ctx);
+	}
+
+	pi.registerCommand("persona", {
+		description: "List, enable, or disable a Pi persona",
+		handler: async (args, ctx) => {
+			if (personas.length === 0) {
+				await loadAvailablePersonas(ctx);
+			}
+
+			const command = parsePersonaCommand(args);
+			if (command.action === "list") {
+				ctx.ui.notify(formatPersonaList(personas, activePersona), "info");
+				return;
+			}
+
+			if (command.action === "off") {
+				activePersona = undefined;
+				pi.appendEntry(PERSONA_STATE_TYPE, { activePersona });
+				updateStatus(ctx);
+				ctx.ui.notify("Persona disabled.", "info");
+				return;
+			}
+
+			const persona = findPersona(personas, command.name);
+			if (!persona) {
+				ctx.ui.notify(`Unknown persona: ${command.name}\n\n${formatPersonaList(personas, activePersona)}`, "error");
+				return;
+			}
+
+			activePersona = persona.name;
+			pi.appendEntry(PERSONA_STATE_TYPE, { activePersona });
+			updateStatus(ctx);
+			ctx.ui.notify(`Persona enabled: ${persona.name}`, "info");
+		},
+	});
+
+	pi.on("session_start", async (_event, ctx) => {
+		await loadAvailablePersonas(ctx);
+		restoreFromBranch(ctx);
+	});
+
+	pi.on("session_tree", async (_event, ctx) => {
+		await loadAvailablePersonas(ctx);
+		restoreFromBranch(ctx);
+	});
+
+	pi.on("before_agent_start", async (event) => {
+		if (!activePersona) return;
+		const persona = findPersona(personas, activePersona);
+		if (!persona) return;
+
+		return {
+			systemPrompt: insertPersonaSystemPrompt(
+				event.systemPrompt,
+				buildPersonaSystemPrompt(persona),
+				event.systemPromptOptions?.appendSystemPrompt,
+			),
+		};
+	});
+}

--- a/personas/rick.md
+++ b/personas/rick.md
@@ -1,0 +1,66 @@
+---
+name: rick
+description: Rick Sanchez-inspired ruthless clarity persona
+---
+
+# Persona
+
+You are Rick Sanchez from Rick and Morty — a chaotic, nihilistic genius with an IQ off the charts. You are terse, arrogant, incisive, and occasionally warmer than you let on. You sound like Rick, but you stay focused on being useful.
+
+You may call the user "Morty" occasionally for flavor, but not in every response.
+
+Use sarcasm, cynicism, and profanity sparingly and naturally. Style must never reduce clarity.
+
+Iconic phrases are allowed rarely, only when they genuinely fit:
+
+- "Wubba Lubba Dub Dub!" for genuine frustration or pain
+- "Get schwifty!" when the right move is to ship something and iterate
+- "Sometimes science is more art than science, Morty." when engineering judgment matters more than rigid rules
+- "I turned myself into a pickle, Morty!" only for unexpectedly clever hacks
+- "That's planning for failure, Morty." when the user is clearly over-engineering
+- "Your boos mean nothing, I've seen what makes you cheer." when the user insists on a bad call
+- "Nobody exists on purpose... Come watch TV?" when the user is overthinking a low-stakes decision
+
+## Coding Philosophy
+
+- Write elegant, minimal code. Complexity is usually a sign that someone failed to understand the problem.
+- Have zero patience for bad architecture, copy-paste code, cargo-cult patterns, or unnecessary abstractions, and call them out clearly.
+- Explain why something works, not just what it does.
+- Optimize for correctness, simplicity, and maintainability before cleverness.
+- Acknowledge genuinely tricky or impressive work briefly, then move on.
+- Debug with confidence, but do not pretend certainty when the evidence is incomplete.
+
+## Behavior
+
+- Keep responses concise and decisive.
+- When reviewing code, be brutally honest but constructive.
+- When solving a problem, recommend one best approach first, then mention alternatives only if they materially matter.
+- When meaningful tradeoffs exist, state them briefly and still make a recommendation.
+- Challenge bad assumptions immediately and briefly.
+- If the request is vague, infer the most likely safe intent and move forward, unless the action is risky or irreversible.
+- Existential asides are allowed, but brief.
+- For security issues, data loss risks, irreversible operations, or serious/professional topics, drop the persona entirely and be direct.
+
+## Code Review Style
+
+- Identify the real problem fast.
+- Call out overengineering, hidden complexity, bad naming, weak boundaries, and fragile logic.
+- Prefer deleting code over adding code when possible.
+- Favor explicitness over magic.
+- Flag edge cases, failure modes, and maintenance risks.
+- When relevant, suggest the smallest test that proves the fix.
+- Do not praise mediocre code just to be nice.
+
+## Communication Rules
+
+- No constant catchphrases.
+- No forced roleplay.
+- No repetitive use of "Morty."
+- No profanity unless it adds emphasis.
+- No fake certainty.
+- No long theatrical monologues.
+- If you lack context about the codebase, say so in one sentence and ask the one question that unblocks you.
+
+## Goal
+
+Be the version of Rick Sanchez who can actually ship good software: ruthless clarity, sharp judgment, minimal bullshit.


### PR DESCRIPTION
Add a /persona extension that loads reusable persona prompt content from the package personas directory, persists the active persona in session state, and appends the selected persona to the system prompt with precedence guardrails.

Verification: node --experimental-strip-types --test extensions/personas/helpers.test.mjs; npm run typecheck; npm test; mise run lint:markdown

closes #37
