### PR TITLE
✨ feat(headroom): Add opt-in proxy routing extension

### DIFF
--- a/extensions/headroom/headroom.test.mjs
+++ b/extensions/headroom/headroom.test.mjs
@@ -1,0 +1,322 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+	buildProviderOverrides,
+	buildProxyArgs,
+	formatStatus,
+	getInstallGuidance,
+	parseHeadroomArgs,
+} from "./helpers.ts";
+import { HeadroomProxyManager } from "./proxy.ts";
+
+test("parses wrap defaults and env overrides", () => {
+	assert.deepEqual(parseHeadroomArgs("wrap", {}), {
+		action: "wrap",
+		port: 8787,
+		mode: "token",
+		binary: "headroom",
+	});
+	assert.deepEqual(parseHeadroomArgs("wrap --port 8877 --mode cache --bin /opt/headroom", {}), {
+		action: "wrap",
+		port: 8877,
+		mode: "cache",
+		binary: "/opt/headroom",
+	});
+	assert.deepEqual(parseHeadroomArgs('wrap --bin "/opt/my headroom/headroom" --mode cache', {}), {
+		action: "wrap",
+		port: 8787,
+		mode: "cache",
+		binary: "/opt/my headroom/headroom",
+	});
+	assert.deepEqual(parseHeadroomArgs("wrap --bin /opt/my\\ headroom/headroom", {}), {
+		action: "wrap",
+		port: 8787,
+		mode: "token",
+		binary: "/opt/my headroom/headroom",
+	});
+	assert.deepEqual(parseHeadroomArgs("stop", { HEADROOM_PORT: "9999", HEADROOM_MODE: "cache", HEADROOM_BIN: "hr" }), {
+		action: "stop",
+		port: 9999,
+		mode: "cache",
+		binary: "hr",
+	});
+});
+
+test("rejects invalid command options", () => {
+	assert.throws(() => parseHeadroomArgs("wrap --mode fast", {}), /--mode/);
+	assert.throws(() => parseHeadroomArgs("wrap --port 99999", {}), /--port/);
+	assert.throws(() => parseHeadroomArgs("wat", {}), /Usage/);
+});
+
+test("builds proxy spawn args", () => {
+	assert.deepEqual(buildProxyArgs({ port: 8877, mode: "cache" }), ["proxy", "--port", "8877", "--mode", "cache"]);
+});
+
+test("builds provider overrides for supported Pi providers", () => {
+	assert.deepEqual(buildProviderOverrides(8787), [
+		{ provider: "openai-codex", config: { baseUrl: "http://127.0.0.1:8787/v1" } },
+		{ provider: "openai", config: { baseUrl: "http://127.0.0.1:8787/v1" } },
+		{ provider: "anthropic", config: { baseUrl: "http://127.0.0.1:8787" } },
+	]);
+});
+
+test("install guidance recommends uv tool install, not npm or pip", () => {
+	const guidance = getInstallGuidance("headroom");
+	assert.match(guidance, /uv tool install --python 3\.12 'headroom-ai\[proxy\]'/);
+	assert.doesNotMatch(guidance, /npm install/);
+	assert.doesNotMatch(guidance, /pip install/);
+});
+
+test("formats status with health and stats summary", () => {
+	const status = formatStatus({
+		enabled: true,
+		managed: true,
+		baseUrl: "http://127.0.0.1:8787",
+		health: { status: "healthy", ready: true, version: "0.22.3" },
+		stats: { summary: { api_requests: 2, compression: { total_tokens_removed: 1234, avg_compression_pct: 42 } } },
+	});
+	assert.match(status, /Headroom: enabled/);
+	assert.match(status, /Proxy: managed by Pi/);
+	assert.match(status, /Health: healthy/);
+	assert.match(status, /Requests: 2/);
+	assert.match(status, /Tokens removed: 1234/);
+});
+
+test("proxy manager reuses healthy external proxy without owning it", async () => {
+	let spawned = false;
+	const manager = new HeadroomProxyManager({ binary: "headroom", port: 8787, mode: "token" }, {
+		spawn: () => {
+			spawned = true;
+			throw new Error("should not spawn");
+		},
+		fetchJson: async () => ({ status: "healthy" }),
+		sleep: async () => {},
+	});
+
+	const result = await manager.ensureRunning();
+	assert.deepEqual(result, { ok: true, managed: false });
+	assert.equal(spawned, false);
+	assert.equal(manager.isManaged, false);
+});
+
+test("proxy manager owns and stops only spawned healthy proxy", async () => {
+	const kills = [];
+	const child = {
+		exitCode: null,
+		kill(signal) {
+			kills.push(signal ?? "default");
+			this.exitCode = 0;
+			return true;
+		},
+		on() { return this; },
+		unref() {},
+	};
+	let healthCalls = 0;
+	const manager = new HeadroomProxyManager({ binary: "headroom", port: 8787, mode: "token" }, {
+		spawn: (command, args) => {
+			assert.equal(command, "headroom");
+			assert.deepEqual(args, ["proxy", "--port", "8787", "--mode", "token"]);
+			return child;
+		},
+		fetchJson: async () => {
+			healthCalls++;
+			if (healthCalls === 1) throw new Error("not running yet");
+			return { status: "healthy" };
+		},
+		sleep: async () => {},
+	});
+
+	const result = await manager.ensureRunning();
+	assert.deepEqual(result, { ok: true, managed: true });
+	assert.equal(manager.isManaged, true);
+
+	await manager.stop();
+	assert.deepEqual(kills, [process.platform === "win32" ? "default" : "SIGTERM"]);
+	assert.equal(manager.isManaged, false);
+});
+
+test("proxy manager does not kill external proxy on stop", async () => {
+	let killed = false;
+	const manager = new HeadroomProxyManager({ binary: "headroom", port: 8787, mode: "token" }, {
+		spawn: () => ({ exitCode: null, kill: () => { killed = true; return true; }, on() { return this; } }),
+		fetchJson: async () => ({ status: "healthy" }),
+		sleep: async () => {},
+	});
+
+	await manager.ensureRunning();
+	await manager.stop();
+	assert.equal(killed, false);
+});
+
+test("proxy manager reports spawn errors such as missing headroom binary", async () => {
+	let errorListener;
+	const manager = new HeadroomProxyManager({ binary: "missing-headroom", port: 8787, mode: "token" }, {
+		spawn: () => ({
+			exitCode: null,
+			kill: () => true,
+			on(event, listener) {
+				if (event === "error") errorListener = listener;
+				return this;
+			},
+		}),
+		fetchJson: async () => { throw new Error("offline"); },
+		sleep: async () => { errorListener?.(new Error("spawn missing-headroom ENOENT")); },
+	});
+
+	const result = await manager.ensureRunning();
+	assert.equal(result.ok, false);
+	assert.match(result.error.message, /ENOENT/);
+});
+
+test("proxy manager kills a spawned proxy that never becomes healthy", async () => {
+	const kills = [];
+	const child = {
+		exitCode: null,
+		kill(signal) {
+			kills.push(signal ?? "default");
+			this.exitCode = 0;
+			return true;
+		},
+		on() { return this; },
+	};
+	const manager = new HeadroomProxyManager({ binary: "headroom", port: 8787, mode: "token" }, {
+		spawn: () => child,
+		fetchJson: async () => { throw new Error("offline"); },
+		sleep: async () => {},
+	});
+
+	const result = await manager.ensureRunning();
+	assert.equal(result.ok, false);
+	assert.deepEqual(kills, [process.platform === "win32" ? "default" : "SIGTERM"]);
+	assert.equal(manager.isManaged, false);
+});
+
+test("proxy manager escalates stubborn managed proxies and suppresses kill races", async () => {
+	const kills = [];
+	let first = true;
+	const child = {
+		exitCode: null,
+		kill(signal) {
+			kills.push(signal ?? "default");
+			if (first) {
+				first = false;
+				return true;
+			}
+			throw new Error("ESRCH");
+		},
+		on() { return this; },
+	};
+	let healthCalls = 0;
+	const manager = new HeadroomProxyManager({ binary: "headroom", port: 8787, mode: "token" }, {
+		spawn: () => child,
+		fetchJson: async () => {
+			healthCalls++;
+			if (healthCalls === 1) throw new Error("offline");
+			return { status: "healthy" };
+		},
+		sleep: async () => {},
+	});
+
+	await manager.ensureRunning();
+	await manager.stop();
+	assert.deepEqual(kills, process.platform === "win32" ? ["default", "default"] : ["SIGTERM", "SIGKILL"]);
+	assert.equal(manager.isManaged, false);
+});
+
+test("proxy manager clears managed state when spawned proxy exits", async () => {
+	let exitListener;
+	const child = {
+		exitCode: null,
+		kill: () => true,
+		on(event, listener) {
+			if (event === "exit") exitListener = listener;
+			return this;
+		},
+	};
+	let healthCalls = 0;
+	const manager = new HeadroomProxyManager({ binary: "headroom", port: 8787, mode: "token" }, {
+		spawn: () => child,
+		fetchJson: async () => {
+			healthCalls++;
+			if (healthCalls === 1) throw new Error("offline");
+			return { status: "healthy" };
+		},
+		sleep: async () => {},
+	});
+
+	await manager.ensureRunning();
+	assert.equal(manager.isManaged, true);
+
+	child.exitCode = 0;
+	exitListener();
+	assert.equal(manager.isManaged, false);
+});
+
+test("proxy manager stops unhealthy managed proxy before restart", async () => {
+	const kills = [];
+	const children = [
+		{
+			exitCode: null,
+			kill(signal) {
+				kills.push(signal ?? "default");
+				this.exitCode = 0;
+				return true;
+			},
+			on() { return this; },
+		},
+		{
+			exitCode: null,
+			kill: () => true,
+			on() { return this; },
+		},
+	];
+	let spawnCount = 0;
+	let healthCalls = 0;
+	const manager = new HeadroomProxyManager({ binary: "headroom", port: 8787, mode: "token" }, {
+		spawn: () => children[spawnCount++],
+		fetchJson: async () => {
+			healthCalls++;
+			if (healthCalls === 1 || healthCalls === 3) throw new Error("offline");
+			return { status: "healthy" };
+		},
+		sleep: async () => {},
+	});
+
+	await manager.ensureRunning();
+	assert.equal(manager.isManaged, true);
+
+	await manager.ensureRunning();
+	assert.equal(spawnCount, 2);
+	assert.deepEqual(kills, [process.platform === "win32" ? "default" : "SIGTERM"]);
+});
+
+test("proxy manager does not claim ownership if spawned proxy exits before external health appears", async () => {
+	let exitListener;
+	const child = {
+		exitCode: null,
+		kill: () => true,
+		on(event, listener) {
+			if (event === "exit") exitListener = listener;
+			return this;
+		},
+	};
+	let healthCalls = 0;
+	const manager = new HeadroomProxyManager({ binary: "headroom", port: 8787, mode: "token" }, {
+		spawn: () => child,
+		fetchJson: async () => {
+			healthCalls++;
+			if (healthCalls === 1) throw new Error("offline");
+			return { status: "healthy" };
+		},
+		sleep: async () => {
+			if (exitListener && child.exitCode === null) {
+				child.exitCode = 0;
+				exitListener();
+			}
+		},
+	});
+
+	const result = await manager.ensureRunning();
+	assert.deepEqual(result, { ok: true, managed: false });
+	assert.equal(manager.isManaged, false);
+});

--- a/extensions/headroom/helpers.ts
+++ b/extensions/headroom/helpers.ts
@@ -1,0 +1,204 @@
+export type HeadroomMode = "token" | "cache";
+export type HeadroomAction = "wrap" | "stop" | "status";
+
+export interface HeadroomOptions {
+	action: HeadroomAction;
+	port: number;
+	mode: HeadroomMode;
+	binary: string;
+}
+
+export interface ProviderOverride {
+	provider: "openai-codex" | "openai" | "anthropic";
+	config: { baseUrl: string };
+}
+
+export const DEFAULT_HEADROOM_PORT = 8787;
+export const DEFAULT_HEADROOM_MODE: HeadroomMode = "token";
+export const DEFAULT_HEADROOM_BINARY = "headroom";
+
+export function parseHeadroomArgs(args: string, env: NodeJS.ProcessEnv = process.env): HeadroomOptions {
+	const tokens = tokenizeArgs(args);
+	const action = parseAction(tokens.shift());
+	let port = parsePort(env.HEADROOM_PORT) ?? DEFAULT_HEADROOM_PORT;
+	let mode = parseMode(env.HEADROOM_MODE) ?? DEFAULT_HEADROOM_MODE;
+	let binary = env.HEADROOM_BIN?.trim() || DEFAULT_HEADROOM_BINARY;
+
+	for (let index = 0; index < tokens.length; index++) {
+		const token = tokens[index];
+		if (token === "--port" || token === "-p") {
+			const value = tokens[++index];
+			const parsed = parsePort(value);
+			if (!parsed) throw new Error("--port requires a valid port number");
+			port = parsed;
+			continue;
+		}
+		if (token?.startsWith("--port=")) {
+			const parsed = parsePort(token.slice("--port=".length));
+			if (!parsed) throw new Error("--port requires a valid port number");
+			port = parsed;
+			continue;
+		}
+		if (token === "--mode") {
+			const parsed = parseMode(tokens[++index]);
+			if (!parsed) throw new Error("--mode must be token or cache");
+			mode = parsed;
+			continue;
+		}
+		if (token?.startsWith("--mode=")) {
+			const parsed = parseMode(token.slice("--mode=".length));
+			if (!parsed) throw new Error("--mode must be token or cache");
+			mode = parsed;
+			continue;
+		}
+		if (token === "--bin" || token === "--binary") {
+			const value = tokens[++index]?.trim();
+			if (!value) throw new Error(`${token} requires a binary path or command`);
+			binary = value;
+			continue;
+		}
+		if (token?.startsWith("--bin=")) {
+			const value = token.slice("--bin=".length).trim();
+			if (!value) throw new Error("--bin requires a binary path or command");
+			binary = value;
+			continue;
+		}
+		if (token?.startsWith("--binary=")) {
+			const value = token.slice("--binary=".length).trim();
+			if (!value) throw new Error("--binary requires a binary path or command");
+			binary = value;
+			continue;
+		}
+		if (token) throw new Error(`Unknown /headroom option: ${token}`);
+	}
+
+	return { action, port, mode, binary };
+}
+
+export function buildProxyArgs(options: Pick<HeadroomOptions, "port" | "mode">): string[] {
+	return ["proxy", "--port", String(options.port), "--mode", options.mode];
+}
+
+export function buildProviderOverrides(port: number, host = "127.0.0.1"): ProviderOverride[] {
+	const base = `http://${host}:${port}`;
+	return [
+		{ provider: "openai-codex", config: { baseUrl: `${base}/v1` } },
+		{ provider: "openai", config: { baseUrl: `${base}/v1` } },
+		{ provider: "anthropic", config: { baseUrl: base } },
+	];
+}
+
+export function getInstallGuidance(binary = DEFAULT_HEADROOM_BINARY): string {
+	return [
+		`Headroom binary not found: ${binary}`,
+		"Install Headroom with uv, then try /headroom wrap again:",
+		"",
+		"  uv tool install --python 3.12 'headroom-ai[proxy]'",
+		"",
+		"If already installed, ensure the headroom command is on PATH or set HEADROOM_BIN.",
+	].join("\n");
+}
+
+export function formatStatus(input: {
+	enabled: boolean;
+	managed: boolean;
+	baseUrl: string;
+	health?: unknown;
+	stats?: unknown;
+}): string {
+	const lines = [
+		`Headroom: ${input.enabled ? "enabled" : "disabled"}`,
+		`Proxy: ${input.managed ? "managed by Pi" : "external or not managed"}`,
+		`URL: ${input.baseUrl}`,
+	];
+
+	const health = input.health as { status?: unknown; ready?: unknown; version?: unknown } | undefined;
+	if (health) {
+		lines.push(`Health: ${String(health.status ?? "unknown")}${health.ready === false ? " (not ready)" : ""}`);
+		if (health.version) lines.push(`Version: ${String(health.version)}`);
+	} else {
+		lines.push("Health: unreachable");
+	}
+
+	const stats = input.stats as { summary?: { api_requests?: unknown; compression?: { total_tokens_removed?: unknown; avg_compression_pct?: unknown } } } | undefined;
+	if (stats?.summary) {
+		lines.push(`Requests: ${String(stats.summary.api_requests ?? 0)}`);
+		const compression = stats.summary.compression;
+		if (compression) {
+			lines.push(`Tokens removed: ${String(compression.total_tokens_removed ?? 0)}`);
+			lines.push(`Average compression: ${String(compression.avg_compression_pct ?? 0)}%`);
+		}
+	}
+
+	return lines.join("\n");
+}
+
+function parseAction(token: string | undefined): HeadroomAction {
+	if (!token || token === "status") return "status";
+	if (token === "wrap" || token === "on" || token === "start") return "wrap";
+	if (token === "stop" || token === "off") return "stop";
+	throw new Error("Usage: /headroom wrap|stop|status [--port <port>] [--mode token|cache] [--bin <headroom>]");
+}
+
+function parsePort(value: string | undefined): number | null {
+	if (!value) return null;
+	const port = Number(value);
+	if (!Number.isInteger(port) || port < 1 || port > 65535) return null;
+	return port;
+}
+
+function parseMode(value: string | undefined): HeadroomMode | null {
+	if (value === "token" || value === "cache") return value;
+	return null;
+}
+
+function tokenizeArgs(args: string): string[] {
+	const tokens: string[] = [];
+	let current = "";
+	let quote: '"' | "'" | null = null;
+
+	for (let index = 0; index < args.length; index++) {
+		const char = args[index];
+
+		if (quote) {
+			if (char === "\\" && index + 1 < args.length) {
+				current += args[index + 1];
+				index += 1;
+				continue;
+			}
+			if (char === quote) {
+				quote = null;
+				continue;
+			}
+			current += char;
+			continue;
+		}
+
+		if (char === "\\" && index + 1 < args.length) {
+			current += args[index + 1];
+			index += 1;
+			continue;
+		}
+
+		if (char === '"' || char === "'") {
+			quote = char;
+			continue;
+		}
+
+		if (/\s/.test(char)) {
+			if (current.length > 0) {
+				tokens.push(current);
+				current = "";
+			}
+			continue;
+		}
+
+		current += char;
+	}
+
+	if (current.length > 0) {
+		tokens.push(current);
+	}
+
+	return tokens;
+}

--- a/extensions/headroom/index.test.mjs
+++ b/extensions/headroom/index.test.mjs
@@ -1,0 +1,143 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerHeadroomExtension } from "./index.ts";
+
+function createHarness(harnessOptions = {}) {
+	const commands = new Map();
+	const events = new Map();
+	const registered = [];
+	const unregistered = [];
+	const selectedModels = [];
+	const notifications = [];
+	const statuses = [];
+	const proxies = [];
+	const pi = {
+		registerCommand(name, definition) {
+			commands.set(name, definition);
+		},
+		on(event, handler) {
+			events.set(event, handler);
+		},
+		registerProvider(provider, config) {
+			registered.push({ provider, config });
+		},
+		unregisterProvider(provider) {
+			unregistered.push(provider);
+		},
+		setModel: async (model) => {
+			selectedModels.push(model);
+			return harnessOptions.setModelResult ?? true;
+		},
+	};
+	const createProxy = (options) => {
+		const proxy = {
+			options,
+			baseUrl: `http://127.0.0.1:${options.port}`,
+			isManaged: true,
+			stopped: false,
+			ensureRunning: async () => harnessOptions.ensureRunning?.(proxy) ?? { ok: true, managed: true },
+			stop: async () => {
+				proxy.stopped = true;
+			},
+			health: async () => ({ status: "healthy" }),
+			stats: async () => ({}),
+		};
+		proxies.push(proxy);
+		return proxy;
+	};
+	const ctx = {
+		hasUI: true,
+		model: { provider: "openai-codex", id: "gpt-5" },
+		waitForIdle: async () => {},
+		ui: {
+			theme: { fg: (_style, text) => text },
+			setStatus: (key, value) => statuses.push({ key, value }),
+			notify: (message, level) => notifications.push({ message, level }),
+		},
+	};
+
+	registerHeadroomExtension(pi, createProxy);
+	return { commands, events, registered, unregistered, selectedModels, notifications, statuses, proxies, ctx };
+}
+
+test("/headroom description advertises binary override option", () => {
+	const { commands } = createHarness();
+	assert.match(commands.get("headroom").description, /--bin <headroom>/);
+});
+
+test("/headroom stop before wrap is a no-op and stop after wrap unregisters providers", async () => {
+	const { commands, registered, unregistered, selectedModels, notifications, proxies, ctx } = createHarness();
+	const handler = commands.get("headroom").handler;
+
+	await handler("stop", ctx);
+	assert.deepEqual(unregistered, []);
+	assert.deepEqual(notifications, []);
+
+	await handler("wrap --port 9999 --mode cache --bin /opt/headroom", ctx);
+	assert.deepEqual(registered.map((entry) => entry.provider), ["openai-codex", "openai", "anthropic"]);
+	assert.deepEqual(registered.map((entry) => entry.config.baseUrl), [
+		"http://127.0.0.1:9999/v1",
+		"http://127.0.0.1:9999/v1",
+		"http://127.0.0.1:9999",
+	]);
+	assert.deepEqual(selectedModels, [ctx.model]);
+	assert.equal(proxies[0].options.binary, "/opt/headroom");
+
+	await handler("stop", ctx);
+	assert.deepEqual(unregistered, ["openai-codex", "openai", "anthropic"]);
+	assert.equal(proxies[0].stopped, true);
+	assert.deepEqual(selectedModels, [ctx.model, ctx.model]);
+	assert.match(notifications.at(-1).message, /Headroom disabled/);
+});
+
+test("/headroom wrap failure detects missing binary through error code", async () => {
+	const error = new Error("spawn failed");
+	error.code = "ENOENT";
+	const { commands, notifications, ctx } = createHarness({
+		ensureRunning: async () => ({ ok: false, error }),
+	});
+
+	await commands.get("headroom").handler("wrap --bin missing-headroom", ctx);
+
+	assert.match(notifications.at(-1).message, /uv tool install/);
+});
+
+test("/headroom wrap failure with existing manager rolls back stale routing", async () => {
+	let ensureCalls = 0;
+	const { commands, unregistered, selectedModels, statuses, ctx } = createHarness({
+		ensureRunning: async () => {
+			ensureCalls++;
+			return ensureCalls === 1 ? { ok: true, managed: true } : { ok: false, error: new Error("offline") };
+		},
+	});
+	const handler = commands.get("headroom").handler;
+
+	await handler("wrap", ctx);
+	await handler("wrap", ctx);
+
+	assert.deepEqual(unregistered, ["openai-codex", "openai", "anthropic"]);
+	assert.deepEqual(selectedModels, [ctx.model, ctx.model]);
+	assert.equal(statuses.at(-1).value, "⚠ Headroom offline");
+});
+
+test("/headroom wrap notes when current provider is not routed", async () => {
+	const { commands, notifications, ctx } = createHarness();
+	ctx.model = { provider: "local", id: "dev-model" };
+
+	await commands.get("headroom").handler("wrap", ctx);
+
+	assert.match(notifications.at(-1).message, /Current provider is local/);
+});
+
+test("session shutdown cleans up only after Headroom registered providers", async () => {
+	const { commands, events, unregistered, proxies, ctx } = createHarness();
+	const shutdown = events.get("session_shutdown");
+
+	await shutdown();
+	assert.deepEqual(unregistered, []);
+
+	await commands.get("headroom").handler("wrap", ctx);
+	await shutdown();
+	assert.deepEqual(unregistered, ["openai-codex", "openai", "anthropic"]);
+	assert.equal(proxies[0].stopped, true);
+});

--- a/extensions/headroom/index.ts
+++ b/extensions/headroom/index.ts
@@ -1,0 +1,208 @@
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { buildProviderOverrides, formatStatus, getInstallGuidance, parseHeadroomArgs, type HeadroomOptions } from "./helpers.ts";
+import { HeadroomProxyManager } from "./proxy.ts";
+
+const STATUS_KEY = "headroom";
+const SUPPORTED_PROVIDERS = ["openai-codex", "openai", "anthropic"] as const;
+
+type CommandContext = ExtensionCommandContext;
+type HeadroomStatus = "enabled" | "disabled" | "starting" | "error" | "routing_pending";
+type CreateProxy = (options: HeadroomOptions) => HeadroomProxyManager;
+
+function createManagedProxy(options: HeadroomOptions): HeadroomProxyManager {
+	return new HeadroomProxyManager({ binary: options.binary, port: options.port, mode: options.mode });
+}
+
+export function registerHeadroomExtension(pi: ExtensionAPI, createProxy: CreateProxy = createManagedProxy): void {
+	let enabled = false;
+	let manager: HeadroomProxyManager | null = null;
+	let managerOptions: HeadroomOptions | null = null;
+	let providerOverridesRegistered = false;
+
+	function setStatus(ctx: CommandContext, status: HeadroomStatus): void {
+		if (!ctx.hasUI) return;
+		const theme = ctx.ui.theme;
+		if (status === "enabled") {
+			ctx.ui.setStatus(STATUS_KEY, theme.fg("success", "✓") + theme.fg("dim", " Headroom"));
+			return;
+		}
+		if (status === "starting") {
+			ctx.ui.setStatus(STATUS_KEY, theme.fg("dim", "⏳ Headroom starting..."));
+			return;
+		}
+		if (status === "routing_pending") {
+			ctx.ui.setStatus(STATUS_KEY, theme.fg("warning", "⚠") + theme.fg("dim", " Headroom pending model switch"));
+			return;
+		}
+		if (status === "error") {
+			ctx.ui.setStatus(STATUS_KEY, theme.fg("warning", "⚠") + theme.fg("dim", " Headroom offline"));
+			return;
+		}
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+	}
+
+	function notify(ctx: CommandContext, message: string, level: "info" | "warning" | "error" = "info"): void {
+		ctx.ui.notify(message, level);
+	}
+
+	function isRoutedProvider(provider: string | undefined): boolean {
+		return !!provider && (SUPPORTED_PROVIDERS as readonly string[]).includes(provider);
+	}
+
+	async function reselectCurrentModel(ctx: CommandContext): Promise<boolean> {
+		if (!ctx.model) return true;
+		let failureDetail = "setModel returned false";
+		try {
+			const selected = await pi.setModel(ctx.model);
+			if (selected) return true;
+		} catch (error) {
+			failureDetail = error instanceof Error ? error.message : String(error);
+		}
+		notify(ctx, `Note: could not reselect the current model (${failureDetail}); routing changes apply after the next model selection.`, "warning");
+		return false;
+	}
+
+	async function applyProviderOverrides(port: number): Promise<void> {
+		for (const override of buildProviderOverrides(port)) {
+			pi.registerProvider(override.provider, override.config);
+		}
+		providerOverridesRegistered = true;
+	}
+
+	async function removeProviderOverrides(): Promise<void> {
+		if (!providerOverridesRegistered) return;
+		for (const provider of SUPPORTED_PROVIDERS) {
+			pi.unregisterProvider(provider);
+		}
+		providerOverridesRegistered = false;
+	}
+
+	function optionsChanged(options: HeadroomOptions): boolean {
+		return !managerOptions || managerOptions.port !== options.port || managerOptions.mode !== options.mode || managerOptions.binary !== options.binary;
+	}
+
+	function isMissingBinaryError(error: Error): boolean {
+		return (error as NodeJS.ErrnoException).code === "ENOENT";
+	}
+
+	async function handleWrap(options: HeadroomOptions, ctx: CommandContext): Promise<void> {
+		await ctx.waitForIdle();
+		setStatus(ctx, "starting");
+
+		const previousManager = manager;
+		const shouldReplaceManager = !manager || optionsChanged(options);
+		const proxy = shouldReplaceManager ? createProxy(options) : manager!;
+		const result = await proxy.ensureRunning((message) => {
+			if (ctx.hasUI) ctx.ui.setStatus(STATUS_KEY, ctx.ui.theme.fg("dim", `⏳ ${message}`));
+		});
+
+		if (!result.ok) {
+			if (shouldReplaceManager) await proxy.stop();
+			const keepExistingRouting = enabled && shouldReplaceManager;
+			if (!keepExistingRouting) {
+				await removeProviderOverrides();
+				enabled = false;
+				manager = null;
+				managerOptions = null;
+				await reselectCurrentModel(ctx);
+			}
+			setStatus(ctx, keepExistingRouting ? "enabled" : "error");
+			const message = isMissingBinaryError(result.error)
+				? getInstallGuidance(options.binary)
+				: `Failed to start Headroom proxy: ${result.error.message}`;
+			notify(ctx, message, "error");
+			return;
+		}
+
+		if (shouldReplaceManager) {
+			manager = proxy;
+			managerOptions = options;
+			if (previousManager && previousManager !== proxy) await previousManager.stop();
+		}
+
+		await applyProviderOverrides(options.port);
+		enabled = true;
+		const routingApplied = await reselectCurrentModel(ctx);
+		setStatus(ctx, routingApplied ? "enabled" : "routing_pending");
+		const details = [
+			`Headroom enabled on ${proxy.baseUrl}`,
+			"Routed providers: openai-codex, openai, anthropic",
+			`Proxy: ${result.managed ? "managed by this Pi session" : "externally detected"}`,
+		];
+		if (ctx.model?.provider && !isRoutedProvider(ctx.model.provider)) {
+			details.push(`Current provider is ${ctx.model.provider}; switch to a routed provider to send traffic through Headroom.`);
+		}
+		notify(
+			ctx,
+			details.join("\n"),
+			"info",
+		);
+	}
+
+	async function handleStop(ctx: CommandContext): Promise<void> {
+		await ctx.waitForIdle();
+		const wasEnabled = enabled;
+		await removeProviderOverrides();
+		enabled = false;
+		if (manager) await manager.stop();
+		manager = null;
+		managerOptions = null;
+		if (wasEnabled) await reselectCurrentModel(ctx);
+		setStatus(ctx, "disabled");
+		if (wasEnabled) notify(ctx, "Headroom disabled; provider routing restored.", "info");
+	}
+
+	async function handleStatus(options: HeadroomOptions, ctx: CommandContext): Promise<void> {
+		const proxy = manager ?? createProxy(options);
+		const [health, stats] = await Promise.all([
+			proxy.health().catch(() => undefined),
+			proxy.stats().catch(() => undefined),
+		]);
+		notify(
+			ctx,
+			formatStatus({
+				enabled,
+				managed: proxy.isManaged,
+				baseUrl: proxy.baseUrl,
+				health,
+				stats,
+			}),
+			health ? "info" : "warning",
+		);
+	}
+
+	pi.registerCommand("headroom", {
+		description: "Route Pi providers through Headroom. Usage: /headroom wrap|stop|status [--port <port>] [--mode token|cache] [--bin <headroom>]",
+		handler: async (args, ctx) => {
+			let options: HeadroomOptions;
+			try {
+				options = parseHeadroomArgs(args);
+			} catch (error) {
+				notify(ctx, error instanceof Error ? error.message : String(error), "error");
+				return;
+			}
+
+			if (options.action === "wrap") {
+				await handleWrap(options, ctx);
+				return;
+			}
+			if (options.action === "stop") {
+				await handleStop(ctx);
+				return;
+			}
+			await handleStatus(options, ctx);
+		},
+	});
+
+	pi.on("session_shutdown", async () => {
+		await removeProviderOverrides();
+		enabled = false;
+		if (manager) await manager.stop();
+		manager = null;
+		managerOptions = null;
+	});
+}
+
+export default function (pi: ExtensionAPI): void {
+	registerHeadroomExtension(pi);
+}

--- a/extensions/headroom/proxy.ts
+++ b/extensions/headroom/proxy.ts
@@ -1,0 +1,168 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { buildProxyArgs, type HeadroomMode } from "./helpers.ts";
+
+export interface HeadroomProxyOptions {
+	binary: string;
+	port: number;
+	mode: HeadroomMode;
+	host?: string;
+}
+
+export interface HeadroomProxyOperations {
+	spawn: (command: string, args: string[], options: { stdio: "ignore"; detached: boolean }) => ManagedProcess;
+	fetchJson: (url: string, timeoutMs: number) => Promise<unknown>;
+	sleep: (ms: number) => Promise<void>;
+}
+
+export interface ManagedProcess {
+	exitCode: number | null;
+	kill: (signal?: NodeJS.Signals) => boolean;
+	on: (event: "error" | "exit", listener: (...args: any[]) => void) => ManagedProcess;
+	unref?: () => void;
+}
+
+const STARTUP_DELAYS_MS = [250, 500, 1000, 1000, 1500, 2000, 2000, 2000];
+
+export class HeadroomProxyManager {
+	private process: ManagedProcess | null = null;
+	private managed = false;
+	private startupError: Error | null = null;
+	private options: HeadroomProxyOptions;
+	private operations: HeadroomProxyOperations;
+
+	constructor(options: HeadroomProxyOptions, operations: Partial<HeadroomProxyOperations> = {}) {
+		this.options = { ...options, host: options.host ?? "127.0.0.1" };
+		this.operations = { ...defaultOperations, ...operations };
+	}
+
+	get baseUrl(): string {
+		return `http://${this.options.host}:${this.options.port}`;
+	}
+
+	get isManaged(): boolean {
+		return this.managed;
+	}
+
+	updateOptions(options: HeadroomProxyOptions): void {
+		this.options = { ...options, host: options.host ?? "127.0.0.1" };
+	}
+
+	async ensureRunning(onStatus?: (message: string) => void): Promise<{ ok: true; managed: boolean } | { ok: false; error: Error }> {
+		if (await this.isHealthy()) {
+			return { ok: true, managed: this.managed };
+		}
+		if (this.process && this.managed) {
+			onStatus?.("Stopping unhealthy Headroom proxy...");
+			await this.stop();
+		}
+
+		try {
+			onStatus?.("Starting Headroom proxy...");
+			this.start();
+		} catch (error) {
+			return { ok: false, error: toError(error) };
+		}
+
+		for (const delay of STARTUP_DELAYS_MS) {
+			await this.operations.sleep(delay);
+			if (this.startupError) {
+				const error = this.startupError;
+				this.clearManagedProcess();
+				return { ok: false, error };
+			}
+			if (await this.isHealthy()) {
+				if (this.process?.exitCode === null) {
+					this.managed = true;
+					return { ok: true, managed: true };
+				}
+				this.clearManagedProcess();
+				return { ok: true, managed: false };
+			}
+			if (this.process?.exitCode !== null) {
+				const error = new Error("Headroom proxy exited before becoming healthy");
+				this.clearManagedProcess();
+				return { ok: false, error };
+			}
+		}
+
+		await this.stop();
+		return { ok: false, error: new Error("Headroom proxy did not become healthy before timeout") };
+	}
+
+	async isHealthy(): Promise<boolean> {
+		try {
+			await this.health();
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	health(): Promise<unknown> {
+		return this.operations.fetchJson(`${this.baseUrl}/health`, 3000);
+	}
+
+	stats(): Promise<unknown> {
+		return this.operations.fetchJson(`${this.baseUrl}/stats`, 3000);
+	}
+
+	async stop(): Promise<void> {
+		if (!this.process || !this.managed) {
+			this.clearManagedProcess();
+			return;
+		}
+
+		const child = this.process;
+		this.clearManagedProcess();
+		try {
+			child.kill(process.platform === "win32" ? undefined : "SIGTERM");
+		} catch {
+			// The child may exit between our state check and signal delivery (for example ESRCH); stop() is best-effort.
+		}
+		await this.operations.sleep(250);
+		if (child.exitCode === null) {
+			try {
+				child.kill(process.platform === "win32" ? undefined : "SIGKILL");
+			} catch {
+				// Same race as SIGTERM: a process that exited during escalation is already stopped.
+			}
+		}
+	}
+
+	private start(): void {
+		this.startupError = null;
+		const child = this.operations.spawn(this.options.binary, buildProxyArgs(this.options), {
+			stdio: "ignore",
+			detached: false,
+		});
+		child.on("error", (error) => {
+			this.startupError = toError(error);
+		});
+		child.on("exit", () => {
+			if (this.process === child) this.clearManagedProcess();
+		});
+		child.unref?.();
+		this.process = child;
+		this.managed = true;
+	}
+
+	private clearManagedProcess(): void {
+		this.process = null;
+		this.managed = false;
+		this.startupError = null;
+	}
+}
+
+const defaultOperations: HeadroomProxyOperations = {
+	spawn: (command, args, options) => spawn(command, args, options) as ChildProcess as ManagedProcess,
+	fetchJson: async (url, timeoutMs) => {
+		const response = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+		if (!response.ok) throw new Error(`HTTP ${response.status}`);
+		return response.json();
+	},
+	sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+};
+
+function toError(error: unknown): Error {
+	return error instanceof Error ? error : new Error(String(error));
+}


### PR DESCRIPTION
Add /headroom wrap, stop, and status commands that manage a local Headroom proxy, dynamically override supported providers, and restore routing without mutating models.json.

Headroom installation remains user-managed; missing binaries report uv tool installation guidance.

Verification: npm test; npm run typecheck

closes #292
