### PR TITLE
🐛 fix(headroom): Wait longer for proxy startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioned sections should match the Git tags and GitHub releases published for t
 
 ### Added
 
+- Added a `/headroom` Pi extension for routing supported providers through a managed or externally detected Headroom proxy.
 - Added cost-focused `/session-breakdown` stats with a compact colorized default report, trend insights, model/directory cost bars, an outlier diagnostic summary, top-5 session/model/directory drill-downs, worktree-aware directory grouping, and cache/context metrics when available. ([#280](https://github.com/ladislas/mypac/issues/280))
 - Added a `/persona` Pi extension and `personas/` prompt-content directory for enabling reusable runtime personas, starting with the preserved Rick persona. ([#37](https://github.com/ladislas/mypac/issues/37))
 - Added a repo-local Worktrunk extension with `/worktree issue <issue-number-or-url>`, issue-derived branch names, create-or-reuse behavior, Worktrunk `pre-start` setup hooks, and workflow documentation for parallel Pi issue work. ([#85](https://github.com/ladislas/mypac/issues/85))
@@ -36,6 +37,10 @@ Versioned sections should match the Git tags and GitHub releases published for t
 ### Removed
 
 - Removed OpenSpec prompts, skills, docs, and artifacts in favor of the GitHub-native planning workflow, and kept `/pac-explore` as a non-OpenSpec discovery mode. ([#216](https://github.com/ladislas/mypac/issues/216))
+
+### Fixed
+
+- Extended Headroom proxy startup waiting and surfaced elapsed startup progress in the `/headroom wrap` status indicator.
 
 ### Changed
 

--- a/extensions/headroom/headroom.test.mjs
+++ b/extensions/headroom/headroom.test.mjs
@@ -168,6 +168,35 @@ test("proxy manager reports spawn errors such as missing headroom binary", async
 	assert.match(result.error.message, /ENOENT/);
 });
 
+test("proxy manager keeps waiting for slow Headroom startup and reports progress", async () => {
+	const child = {
+		exitCode: null,
+		kill: () => true,
+		on() { return this; },
+	};
+	let healthCalls = 0;
+	const sleeps = [];
+	const statuses = [];
+	const manager = new HeadroomProxyManager({ binary: "headroom", port: 8787, mode: "token" }, {
+		spawn: () => child,
+		fetchJson: async () => {
+			healthCalls++;
+			if (healthCalls < 16) throw new Error("offline");
+			return { status: "healthy" };
+		},
+		sleep: async (ms) => {
+			sleeps.push(ms);
+		},
+	});
+
+	const result = await manager.ensureRunning((message) => statuses.push(message));
+
+	assert.deepEqual(result, { ok: true, managed: true });
+	assert.equal(manager.isManaged, true);
+	assert.ok(sleeps.reduce((total, delay) => total + delay, 0) > 10_250);
+	assert.ok(statuses.some((message) => /Waiting for Headroom proxy/.test(message)));
+});
+
 test("proxy manager kills a spawned proxy that never becomes healthy", async () => {
 	const kills = [];
 	const child = {

--- a/extensions/headroom/index.test.mjs
+++ b/extensions/headroom/index.test.mjs
@@ -10,6 +10,7 @@ function createHarness(harnessOptions = {}) {
 	const selectedModels = [];
 	const notifications = [];
 	const statuses = [];
+	const calls = [];
 	const proxies = [];
 	const pi = {
 		registerCommand(name, definition) {
@@ -35,7 +36,7 @@ function createHarness(harnessOptions = {}) {
 			baseUrl: `http://127.0.0.1:${options.port}`,
 			isManaged: true,
 			stopped: false,
-			ensureRunning: async () => harnessOptions.ensureRunning?.(proxy) ?? { ok: true, managed: true },
+			ensureRunning: async (onStatus) => harnessOptions.ensureRunning?.(proxy, onStatus) ?? { ok: true, managed: true },
 			stop: async () => {
 				proxy.stopped = true;
 			},
@@ -48,16 +49,24 @@ function createHarness(harnessOptions = {}) {
 	const ctx = {
 		hasUI: true,
 		model: { provider: "openai-codex", id: "gpt-5" },
-		waitForIdle: async () => {},
+		waitForIdle: async () => {
+			calls.push("waitForIdle");
+			await harnessOptions.waitForIdle?.();
+		},
 		ui: {
 			theme: { fg: (_style, text) => text },
-			setStatus: (key, value) => statuses.push({ key, value }),
+			setStatus: (key, value) => {
+				calls.push(`setStatus:${value}`);
+				statuses.push({ key, value });
+			},
+			setWorkingMessage: (message) => calls.push(`setWorkingMessage:${message ?? ""}`),
+			setWorkingVisible: (visible) => calls.push(`setWorkingVisible:${visible}`),
 			notify: (message, level) => notifications.push({ message, level }),
 		},
 	};
 
 	registerHeadroomExtension(pi, createProxy);
-	return { commands, events, registered, unregistered, selectedModels, notifications, statuses, proxies, ctx };
+	return { commands, events, registered, unregistered, selectedModels, notifications, statuses, proxies, calls, ctx };
 }
 
 test("/headroom description advertises binary override option", () => {
@@ -88,6 +97,34 @@ test("/headroom stop before wrap is a no-op and stop after wrap unregisters prov
 	assert.equal(proxies[0].stopped, true);
 	assert.deepEqual(selectedModels, [ctx.model, ctx.model]);
 	assert.match(notifications.at(-1).message, /Headroom disabled/);
+});
+
+test("/headroom wrap shows working indicator before waiting for idle", async () => {
+	const { commands, calls, notifications, ctx } = createHarness();
+
+	await commands.get("headroom").handler("wrap", ctx);
+
+	assert.equal(calls[0], "setStatus:⏳ Headroom starting...");
+	assert.equal(calls[1], "setWorkingMessage:Starting Headroom proxy...");
+	assert.equal(calls[2], "setWorkingVisible:true");
+	assert.equal(calls[3], "waitForIdle");
+	assert.match(notifications[0].message, /Starting Headroom proxy/);
+	assert.equal(calls.at(-2), "setWorkingMessage:");
+	assert.equal(calls.at(-1), "setWorkingVisible:false");
+});
+
+test("/headroom wrap shows proxy startup progress in status UI", async () => {
+	const { commands, statuses, calls, ctx } = createHarness({
+		ensureRunning: async (_proxy, onStatus) => {
+			onStatus("Waiting for Headroom proxy... 12s elapsed");
+			return { ok: true, managed: true };
+		},
+	});
+
+	await commands.get("headroom").handler("wrap", ctx);
+
+	assert.ok(statuses.some((status) => status.value === "⏳ Waiting for Headroom proxy... 12s elapsed"));
+	assert.ok(calls.some((call) => call === "setWorkingMessage:Waiting for Headroom proxy... 12s elapsed"));
 });
 
 test("/headroom wrap failure detects missing binary through error code", async () => {
@@ -126,7 +163,7 @@ test("/headroom wrap notes when current provider is not routed", async () => {
 
 	await commands.get("headroom").handler("wrap", ctx);
 
-	assert.match(notifications.at(-1).message, /Current provider is local/);
+	assert.ok(notifications.some((notification) => /Current provider is local/.test(notification.message)));
 });
 
 test("session shutdown cleans up only after Headroom registered providers", async () => {

--- a/extensions/headroom/index.ts
+++ b/extensions/headroom/index.ts
@@ -45,6 +45,12 @@ export function registerHeadroomExtension(pi: ExtensionAPI, createProxy: CreateP
 		ctx.ui.notify(message, level);
 	}
 
+	function setWorkingMessage(ctx: CommandContext, message: string | undefined): void {
+		if (!ctx.hasUI) return;
+		ctx.ui.setWorkingMessage(message);
+		ctx.ui.setWorkingVisible(message !== undefined);
+	}
+
 	function isRoutedProvider(provider: string | undefined): boolean {
 		return !!provider && (SUPPORTED_PROVIDERS as readonly string[]).includes(provider);
 	}
@@ -86,57 +92,62 @@ export function registerHeadroomExtension(pi: ExtensionAPI, createProxy: CreateP
 	}
 
 	async function handleWrap(options: HeadroomOptions, ctx: CommandContext): Promise<void> {
-		await ctx.waitForIdle();
 		setStatus(ctx, "starting");
+		notify(ctx, `Starting Headroom proxy on port ${options.port}...`, "info");
+		setWorkingMessage(ctx, "Starting Headroom proxy...");
+		try {
+			await ctx.waitForIdle();
 
-		const previousManager = manager;
-		const shouldReplaceManager = !manager || optionsChanged(options);
-		const proxy = shouldReplaceManager ? createProxy(options) : manager!;
-		const result = await proxy.ensureRunning((message) => {
-			if (ctx.hasUI) ctx.ui.setStatus(STATUS_KEY, ctx.ui.theme.fg("dim", `⏳ ${message}`));
-		});
+			const previousManager = manager;
+			const shouldReplaceManager = !manager || optionsChanged(options);
+			const proxy = shouldReplaceManager ? createProxy(options) : manager!;
+			const result = await proxy.ensureRunning((message) => {
+				if (ctx.hasUI) {
+					ctx.ui.setStatus(STATUS_KEY, ctx.ui.theme.fg("dim", `⏳ ${message}`));
+					setWorkingMessage(ctx, message);
+				}
+			});
 
-		if (!result.ok) {
-			if (shouldReplaceManager) await proxy.stop();
-			const keepExistingRouting = enabled && shouldReplaceManager;
-			if (!keepExistingRouting) {
-				await removeProviderOverrides();
-				enabled = false;
-				manager = null;
-				managerOptions = null;
-				await reselectCurrentModel(ctx);
+			if (!result.ok) {
+				if (shouldReplaceManager) await proxy.stop();
+				const keepExistingRouting = enabled && shouldReplaceManager;
+				if (!keepExistingRouting) {
+					await removeProviderOverrides();
+					enabled = false;
+					manager = null;
+					managerOptions = null;
+					await reselectCurrentModel(ctx);
+				}
+				setStatus(ctx, keepExistingRouting ? "enabled" : "error");
+				const message = isMissingBinaryError(result.error)
+					? getInstallGuidance(options.binary)
+					: `Failed to start Headroom proxy: ${result.error.message}`;
+				notify(ctx, message, "error");
+				return;
 			}
-			setStatus(ctx, keepExistingRouting ? "enabled" : "error");
-			const message = isMissingBinaryError(result.error)
-				? getInstallGuidance(options.binary)
-				: `Failed to start Headroom proxy: ${result.error.message}`;
-			notify(ctx, message, "error");
-			return;
-		}
 
-		if (shouldReplaceManager) {
-			manager = proxy;
-			managerOptions = options;
-			if (previousManager && previousManager !== proxy) await previousManager.stop();
-		}
+			if (shouldReplaceManager) {
+				manager = proxy;
+				managerOptions = options;
+				if (previousManager && previousManager !== proxy) await previousManager.stop();
+			}
 
-		await applyProviderOverrides(options.port);
-		enabled = true;
-		const routingApplied = await reselectCurrentModel(ctx);
-		setStatus(ctx, routingApplied ? "enabled" : "routing_pending");
-		const details = [
-			`Headroom enabled on ${proxy.baseUrl}`,
-			"Routed providers: openai-codex, openai, anthropic",
-			`Proxy: ${result.managed ? "managed by this Pi session" : "externally detected"}`,
-		];
-		if (ctx.model?.provider && !isRoutedProvider(ctx.model.provider)) {
-			details.push(`Current provider is ${ctx.model.provider}; switch to a routed provider to send traffic through Headroom.`);
+			await applyProviderOverrides(options.port);
+			enabled = true;
+			const routingApplied = await reselectCurrentModel(ctx);
+			setStatus(ctx, routingApplied ? "enabled" : "routing_pending");
+			const details = [
+				`Headroom enabled on ${proxy.baseUrl}`,
+				"Routed providers: openai-codex, openai, anthropic",
+				`Proxy: ${result.managed ? "managed by this Pi session" : "externally detected"}`,
+			];
+			if (ctx.model?.provider && !isRoutedProvider(ctx.model.provider)) {
+				details.push(`Current provider is ${ctx.model.provider}; switch to a routed provider to send traffic through Headroom.`);
+			}
+			notify(ctx, details.join("\n"), "info");
+		} finally {
+			setWorkingMessage(ctx, undefined);
 		}
-		notify(
-			ctx,
-			details.join("\n"),
-			"info",
-		);
 	}
 
 	async function handleStop(ctx: CommandContext): Promise<void> {

--- a/extensions/headroom/proxy.ts
+++ b/extensions/headroom/proxy.ts
@@ -21,7 +21,8 @@ export interface ManagedProcess {
 	unref?: () => void;
 }
 
-const STARTUP_DELAYS_MS = [250, 500, 1000, 1000, 1500, 2000, 2000, 2000];
+const STARTUP_TIMEOUT_MS = 60_000;
+const STARTUP_POLL_INTERVAL_MS = 1_000;
 
 export class HeadroomProxyManager {
 	private process: ManagedProcess | null = null;
@@ -63,8 +64,11 @@ export class HeadroomProxyManager {
 			return { ok: false, error: toError(error) };
 		}
 
-		for (const delay of STARTUP_DELAYS_MS) {
+		let waitedMs = 0;
+		while (waitedMs < STARTUP_TIMEOUT_MS) {
+			const delay = Math.min(STARTUP_POLL_INTERVAL_MS, STARTUP_TIMEOUT_MS - waitedMs);
 			await this.operations.sleep(delay);
+			waitedMs += delay;
 			if (this.startupError) {
 				const error = this.startupError;
 				this.clearManagedProcess();
@@ -83,10 +87,11 @@ export class HeadroomProxyManager {
 				this.clearManagedProcess();
 				return { ok: false, error };
 			}
+			onStatus?.(`Waiting for Headroom proxy... ${Math.round(waitedMs / 1000)}s elapsed`);
 		}
 
 		await this.stop();
-		return { ok: false, error: new Error("Headroom proxy did not become healthy before timeout") };
+		return { ok: false, error: new Error(`Headroom proxy did not become healthy within ${Math.round(STARTUP_TIMEOUT_MS / 1000)}s`) };
 	}
 
 	async isHealthy(): Promise<boolean> {


### PR DESCRIPTION
Extend managed Headroom startup health checks to 60s and keep the Pi status indicator updated while waiting.

Verification: npm test

Verification: npm run typecheck
