### PR TITLE
✨ feat(prompts): Split planning and execution workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For readability, the skill table below drops the `pac-` prefix in the display la
 | [`personas`](extensions/personas/) | `/persona` | Lists, enables, and disables reusable persona prompt content from [`personas/`](personas/) |
 | [`review`](extensions/review/) | `/review-start`, `/review-end` | Reviews uncommitted changes, commits, branches, PRs, or folders from inside Pi |
 | [`session-breakdown`](extensions/session-breakdown/) | `/session-breakdown` | Shows local Pi session usage, cost, model, directory, and cache/context statistics without printing raw transcripts |
-| [`session-names`](extensions/session-names/) | background behavior | Names `/pac-lwot` sessions from the work context you provide |
+| [`session-names`](extensions/session-names/) | background behavior | Names `/pac-llat` and `/pac-lwot` sessions from the work context you provide |
 | [`shared-append-system`](extensions/shared-append-system/) | background behavior | Injects shared append-system instructions into the session system prompt |
 | [`slidedeck`](extensions/slidedeck/) | `/pac-slidedeck` | Generates a self-contained HTML slidedeck and saves it under `~/.pi/agent/slidedecks/` instead of the repo workspace |
 | [`todos`](extensions/todos/) | `todo` tool, `/todos` | Adds a file-based todo system under `.pi/todos` with claiming, status, and notes |
@@ -76,7 +76,8 @@ For readability, the skill table below drops the `pac-` prefix in the display la
 | Prompt | Purpose |
 | --- | --- |
 | [`/pac-hello-world`](prompts/pac-hello-world.md) | Quick validation prompt to confirm the package is loaded |
-| [`/pac-lwot`](prompts/pac-lwot.md) | "Let's work on that" — turn a note, issue, PR, todo, or URL into a concrete plan and next steps |
+| [`/pac-llat`](prompts/pac-llat.md) | "Let's look at that" — analyze, discuss, reframe, and plan before implementation |
+| [`/pac-lwot`](prompts/pac-lwot.md) | "Let's work on that" — start implementation from a note, issue, PR, todo, PRD, URL, or conversation context |
 | [`/pac-zoom-out`](prompts/pac-zoom-out.md) | Zoom out from a code area and map relevant modules, callers, and system fit |
 | [`/pac-ldit`](prompts/pac-ldit.md) | "Let's do it" — confirm and proceed with already-planned work |
 | [`/pac-diagnose`](prompts/pac-diagnose.md) | Diagnose a bug or performance regression with a disciplined feedback-loop workflow |
@@ -128,7 +129,8 @@ After install, if Pi is already running, use `/reload` or restart Pi.
 Useful first commands:
 
 - `/pac-hello-world`
-- `/pac-lwot [optional text|github issue|github pr|url]`
+- `/pac-llat [idea|issue/PR URL|PRD|todo ID|free text]`
+- `/pac-lwot [note|issue/PR URL|PRD|todo ID|free text]`
 - `/pac-slidedeck turn issue #131 into a review deck`
 
 `/pac-slidedeck` saves the generated HTML outside the repo under `~/.pi/agent/slidedecks/<session-id>/...`, so deck artifacts do not pollute your workspace.

--- a/extensions/session-breakdown/README.md
+++ b/extensions/session-breakdown/README.md
@@ -4,7 +4,7 @@ Registers `/session-breakdown` to summarize local Pi usage from JSONL files unde
 
 The default command output is a compact, colorized report with an overview table, cost insights, model/directory cost bars, an outlier diagnostic summary, and readable top-5 drill-down sections for expensive sessions, model efficiency, directory cost centers, and cache/context metrics when available. Git worktrees are grouped under their canonical repository in directory cost centers. Use `--no-color` to disable ANSI color in the report.
 
-Workflow categories use a lightweight privacy-safe heuristic from session file paths and working directories only: names containing `lwot`, `grill`, `review`, or `triage` map to those categories; names containing implementation-ish words such as `feature`, `bugfix`, `fix`, `commit`, or `implementation` map to `implementation`; everything else is `other`.
+Workflow categories use a lightweight privacy-safe heuristic from session file paths and working directories only: names containing `llat`, `lwot`, `grill`, `review`, or `triage` map to those categories; names containing implementation-ish words such as `feature`, `bugfix`, `fix`, `commit`, or `implementation` map to `implementation`; everything else is `other`.
 
 Privacy notes:
 

--- a/extensions/session-breakdown/helpers.test.mjs
+++ b/extensions/session-breakdown/helpers.test.mjs
@@ -187,7 +187,7 @@ test("analyzeSessionDirectory aggregates session costs and inferred workflow cat
 	try {
 		await mkdir(join(root, "--project--"));
 		const sessions = [
-			["2026-05-20T10-00-00-000Z_pac-lwot.jsonl", "/Users/alice/dev/project", "openai-codex", "gpt-5.5", 100, 1],
+			["2026-05-20T10-00-00-000Z_pac-llat.jsonl", "/Users/alice/dev/project", "openai-codex", "gpt-5.5", 100, 1],
 			["2026-05-20T11-00-00-000Z_grill-design.jsonl", "/Users/alice/dev/project", "openai-codex", "gpt-5.5", 200, 2],
 			["2026-05-20T12-00-00-000Z_review.jsonl", "/Users/alice/dev/project", "anthropic", "claude", 300, 3],
 			["2026-05-20T13-00-00-000Z_feature-thing.jsonl", "/Users/alice/dev/project", "anthropic", "claude", 400, 4],
@@ -206,7 +206,7 @@ test("analyzeSessionDirectory aggregates session costs and inferred workflow cat
 		const range = report.ranges.get(7);
 		assert.ok(range);
 		assert.deepEqual(range.sessionCosts, [1, 2, 3, 4]);
-		assert.equal(range.workflowStats.get("lwot")?.totalCost, 1);
+		assert.equal(range.workflowStats.get("llat")?.totalCost, 1);
 		assert.equal(range.workflowStats.get("grill")?.totalCost, 2);
 		assert.equal(range.workflowStats.get("review")?.totalCost, 3);
 		assert.equal(range.workflowStats.get("implementation")?.totalCost, 4);

--- a/extensions/session-breakdown/helpers.ts
+++ b/extensions/session-breakdown/helpers.ts
@@ -427,6 +427,7 @@ function deriveFallbackTitle(state: SessionParseState): string | null {
 
 function inferWorkflowType(session: ParsedSession): string {
 	const text = basename(session.filePath).toLowerCase();
+	if (/(^|[-_])(?:pac-)?llat([-_.]|$)/.test(text)) return "llat";
 	if (/(^|[-_])(?:pac-)?lwot([-_.]|$)/.test(text)) return "lwot";
 	if (/(^|[-_])grill([-_.]|$)/.test(text)) return "grill";
 	if (/(^|[-_])review([-_.]|$)/.test(text)) return "review";

--- a/extensions/session-names/index.ts
+++ b/extensions/session-names/index.ts
@@ -1,20 +1,26 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { buildWorkflowSessionName, extractSlashCommandArgument } from "./helpers.ts";
 
+const WORKFLOW_COMMANDS = [
+	{ command: "pac-llat", workflow: "llat" },
+	{ command: "pac-lwot", workflow: "lwot" },
+] as const;
+
 export default function sessionNamesExtension(pi: ExtensionAPI): void {
 	pi.on("input", async (event) => {
 		if (event.source === "extension") {
 			return { action: "continue" };
 		}
 
-		const input = extractSlashCommandArgument(event.text, "pac-lwot");
-		if (input === null) {
-			return { action: "continue" };
-		}
+		for (const { command, workflow } of WORKFLOW_COMMANDS) {
+			const input = extractSlashCommandArgument(event.text, command);
+			if (input === null) continue;
 
-		const sessionName = buildWorkflowSessionName("lwot", input);
-		if (sessionName) {
-			pi.setSessionName(sessionName);
+			const sessionName = buildWorkflowSessionName(workflow, input);
+			if (sessionName) {
+				pi.setSessionName(sessionName);
+			}
+			return { action: "continue" };
 		}
 
 		return { action: "continue" };

--- a/extensions/session-names/session-names.test.mjs
+++ b/extensions/session-names/session-names.test.mjs
@@ -37,6 +37,7 @@ test("buildWorkflowSessionName returns undefined without usable input", () => {
 
 test("buildWorkflowSessionName prefixes normalized input", () => {
 	assert.equal(buildWorkflowSessionName("lwot", "  fix README install steps  "), "lwot - fix README install steps");
+	assert.equal(buildWorkflowSessionName("llat", "  issue #295  "), "llat - issue #295");
 });
 
 test("extractSlashCommandArgument finds pac-lwot input", () => {

--- a/prompts/pac-ldit.md
+++ b/prompts/pac-ldit.md
@@ -7,7 +7,7 @@ Let's do it.
 
 Proceed with the most recently agreed plan in this conversation.
 Use the provided argument only as extra clarification or scope refinement.
-If there is no clear plan to execute yet, ask a brief clarifying question or suggest `/pac-lwot` first.
+If there is no clear plan to execute yet, ask a brief clarifying question or suggest `/pac-llat` first.
 
 If the agreed plan includes behavior-changing implementation, a bug fix, or work that needs regression coverage, read and follow `skills/pac-tdd/SKILL.md` before implementing that slice.
 Skip `pac-tdd` for docs-only, wording-only, mechanical rename, config-only, planning-only, or diagnostic-only plans unless tests are directly relevant.

--- a/prompts/pac-llat.md
+++ b/prompts/pac-llat.md
@@ -1,0 +1,33 @@
+---
+description: "Analyze and plan work without implementing"
+argument-hint: "[idea | issue/PR URL | PRD | todo ID | free text]"
+---
+
+Let's look at that.
+
+Use this prompt for exploration, reframing, planning, and deciding the next workflow. Do not edit files, create commits, run mutating commands, post GitHub comments, or otherwise implement unless the user explicitly switches to execution.
+
+Process:
+
+1. Resolve the target from the provided argument, current conversation, linked issue/PR, PRD, todo, URL, or artifact. If the target is unclear, ask one concise clarifying question.
+2. Summarize the goal, current context, assumptions, and known constraints.
+3. Decide whether the work is:
+   - simple and ready for implementation,
+   - ambiguous and needs exploration,
+   - issue-backed and needs grilling/documented decisions,
+   - large enough for a PRD,
+   - ready to break into implementation issues,
+   - out of scope or not worth doing.
+4. Route to existing workflows instead of duplicating them:
+   - `/pac-explore` for open-ended discovery,
+   - `/pac-grill-me` for conversational design stress-testing,
+   - `/pac-grill-with-docs` for issue-backed refinement with durable notes,
+   - `/pac-to-prd` for larger product/design artifacts,
+   - `/pac-to-issues` for decomposing agreed plans,
+   - `/pac-lwot` when the user wants implementation.
+5. If the work is ready, produce a short implementation-ready brief: goal, files likely involved, risks, verification, and open questions.
+6. Stop before implementation and ask what the user wants next.
+
+Keep the response concise. Prefer questions and recommendations over speculative coding.
+
+**Provided arguments**: $@

--- a/prompts/pac-lwot.md
+++ b/prompts/pac-lwot.md
@@ -1,77 +1,29 @@
 ---
-description: "Turn a note, GitHub issue or PR, todo, or URL into a concrete plan and next steps"
-argument-hint: "[text | GitHub issue/PR | todo ID | URL]"
+description: "Start implementation from a note, issue, PR, todo, PRD, URL, or conversation context"
+argument-hint: "[note | issue/PR URL | PRD | todo ID | free text]"
 ---
 
 Let's work on that.
 
-Default to planning before implementation. Unless the task is truly straightforward and clearly ready to execute, explain the plan first and ask the user for confirmation before making changes. If the user may be discussing, exploring, or clarifying rather than asking for immediate implementation, lean on the side of caution and confirm before starting work.
+Use this prompt when the user wants execution from available context. The target may be conversation history, a GitHub issue or PR, a todo, a PRD, a URL, a note, or a concrete request.
 
-Use the optional argument after `/pac-lwot` as the thing we should work from. It may be:
+If the user is still exploring, debating scope, asking whether something is worth doing, or asking for options, recommend `/pac-llat` instead of starting implementation.
 
-- a free-form description of the work
-- a GitHub issue or PR URL
-- a todo ID (e.g. `TODO-abc123`)
-- another URL
-- nothing, in which case infer from the conversation and ask only if unclear
+Process:
 
-**Input**: Optional context for the work: free text, GitHub issue/PR, todo ID, or another URL.
+1. Resolve the target. Prefer explicit arguments, then current conversation context. For GitHub issues/PRs, read the relevant GitHub context. For todos, read the todo before editing.
+2. Check repository state and branch. Do not work directly on `main`; create or switch to a properly named branch when needed.
+3. State the goal, assumptions, and any ambiguity. If intent or scope is unclear, ask before editing.
+4. Give a short implementation plan and verification plan before making changes.
+5. Load specialized skills only when relevant:
+   - `skills/pac-tdd/SKILL.md` for behavior-changing implementation, bug fixes, or regression coverage.
+   - `skills/pac-pi-prompt/SKILL.md` when creating or updating prompts.
+   - `skills/pac-pi-extension/SKILL.md` when touching extension code.
+   - `/pac-llat`, `/pac-explore`, `/pac-grill-with-docs`, `/pac-to-prd`, or `/pac-to-issues` when the request needs more planning instead of coding.
+6. Implement the smallest slice that satisfies the request. Keep changes surgical and directly tied to the target. Avoid unrelated refactors.
+7. Verify with the smallest relevant checks. Report what changed, what was verified, and any remaining follow-up.
+8. For meaningful completed slices, create atomic commits according to `skills/pac-commit/SKILL.md` when asked or when the implementation workflow calls for it. If the work originated from a GitHub issue, include `closes #<issue-number>` in the resolving commit body. Do not guess issue numbers.
 
-## Behavior
-
-1. **Resolve the target**
-   - If an argument is provided, use it.
-   - If no argument is provided, infer what "that" refers to from the conversation.
-   - If it is still unclear, ask a concise clarifying question before proceeding.
-
-2. **Check branch safety**
-   - Check the current git branch and note whether it is a protected/default branch (`main` or equivalent).
-   - This is a read-only check only — do not create or switch branches yet.
-   - If already on a non-protected feature branch, note that and continue.
-
-3. **Gather the minimum context needed**
-   - **Free text**: restate the goal in your own words and inspect the repository as needed.
-   - **GitHub issue**: use the `gh` CLI (or the URL directly) to read the title, body, status, and the most relevant comments. If the body has reserved sections such as `## PRDs` or `## Decisions`, read those sections first, follow the linked artifacts, prefer the newest linked comment that actually contains `<!-- pac:prd -->`, and treat linked `<!-- pac:adr -->` comments as decision constraints. When these structured artifacts exist, do not treat all comments as equal. If a linked artifact is stale, unreadable, or missing the expected marker, say so plainly and fall back to the minimum direct issue context needed.
-   - **GitHub PR**: use the `gh` CLI (or the URL directly) to read the title, body, status, and the most relevant review notes or comments.
-   - **Todo ID**: read the todo with the `todo` tool (`action: get, id: <id>`) to retrieve its title, body, and status.
-   - **Other URL**: fetch or read the page or resource and extract only the parts needed to do the work.
-   - If a URL cannot be accessed because of auth, networking, or unsupported content, say so plainly and ask the user to paste the relevant context.
-
-4. **Frame the work before changing code**
-   - State your assumptions.
-   - Define the smallest useful outcome.
-   - Give a short plan before starting work, especially for anything non-trivial.
-   - When working from a GitHub issue, explicitly report which artifacts informed the plan: issue body, linked PRD comment(s), linked ADR comment(s), or fallback comments.
-   - Unless the task is truly straightforward and the user's intent to implement is explicit, ask for confirmation before making changes.
-
-5. **Choose the right path**
-   - For very small, clear, implementation-ready work, proceed directly.
-   - For anything that may still be under discussion, present the plan and ask whether to proceed.
-   - For meaningful multi-step work that is not implementation-ready, suggest the GitHub-native planning path: `/pac-explore` for discovery, `/pac-grill-with-docs` for issue-backed refinement, `/pac-to-prd` for PRD synthesis, or `/pac-to-issues` for implementation slices.
-   - If the input is exploratory rather than actionable, suggest `/pac-explore`.
-
-6. **Do the work**
-   - Only start implementation once you have either user confirmation or a truly straightforward request that is clearly asking for execution now.
-   - If Step 2 flagged a protected branch, create and switch to a properly named branch now, before touching any files. Use the repository naming convention (`<firstname>/<type>/<topic-more_info>`, where type is one of `feature`, `bugfix`, or `release`) with a topic slug derived from the work context gathered in Steps 3–4.
-   - If the selected work changes runtime behavior, fixes a bug, or needs regression coverage, read and follow `skills/pac-tdd/SKILL.md` before implementing.
-   - Do not load `pac-tdd` for docs-only, wording-only, mechanical rename, config-only, planning-only, or diagnostic-only work unless tests are directly relevant.
-   - For meaningful completed slices of work, create atomic commits during implementation rather than waiting until the very end.
-   - If the work originated from a GitHub issue (passed as the argument), include `closes #<issue-number>` in the commit body of the commit that resolves the issue. Do not guess issue numbers.
-   - Keep changes minimal and directly tied to the request.
-   - Match existing style and avoid unrelated refactors.
-   - Use GitHub context and linked URLs as supporting material, not as permission to expand scope.
-
-7. **Verify and report**
-   - Run the smallest relevant checks.
-   - Summarize what you changed, what you verified, which artifacts informed the work, and any open questions.
-
-## Examples
-
-- `/pac-lwot fix the README install instructions`
-- `/pac-lwot https://github.com/owner/repo/issues/123`
-  If the issue links multiple PRD iterations under `## PRDs`, prefer the latest linked `<!-- pac:prd -->` comment and treat linked ADRs under `## Decisions` as constraints.
-- `/pac-lwot https://github.com/owner/repo/pull/456`
-- `/pac-lwot https://example.com/spec-notes`
-- `/pac-lwot TODO-abc123`
+Use GitHub context and linked artifacts as supporting material, not permission to expand scope.
 
 **Provided arguments**: $@


### PR DESCRIPTION
Add /pac-llat for planning-only analysis and narrow /pac-lwot toward implementation from resolved context. Update session naming, session breakdown categorization, and README references.\n\ncloses #295
